### PR TITLE
Add PalmQuest Godot training experience

### DIFF
--- a/PalmQuest/assets/icons/badge.svg
+++ b/PalmQuest/assets/icons/badge.svg
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="96" height="96" viewBox="0 0 96 96" xmlns="http://www.w3.org/2000/svg">
+  <path d="M48 8 L68 20 L76 44 L64 68 L48 76 L32 68 L20 44 L28 20 Z" fill="#ffe27d" stroke="#d18c1d" stroke-width="4"/>
+  <circle cx="48" cy="44" r="12" fill="#fff4c1" stroke="#d18c1d" stroke-width="4"/>
+  <path d="M40 88 L48 76 L56 88 L48 92 Z" fill="#d18c1d"/>
+</svg>

--- a/PalmQuest/assets/icons/dashboard.svg
+++ b/PalmQuest/assets/icons/dashboard.svg
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="96" height="96" viewBox="0 0 96 96" xmlns="http://www.w3.org/2000/svg">
+  <rect x="12" y="18" width="72" height="60" rx="12" fill="#ecf8f2" stroke="#3d8f6a" stroke-width="4"/>
+  <rect x="24" y="30" width="12" height="32" rx="4" fill="#3d8f6a"/>
+  <rect x="42" y="40" width="12" height="22" rx="4" fill="#50b189"/>
+  <rect x="60" y="34" width="12" height="28" rx="4" fill="#81d2b0"/>
+  <path d="M20 70 H76" stroke="#3d8f6a" stroke-width="4" stroke-linecap="round"/>
+</svg>

--- a/PalmQuest/assets/icons/fertilizer.svg
+++ b/PalmQuest/assets/icons/fertilizer.svg
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="96" height="96" viewBox="0 0 96 96" xmlns="http://www.w3.org/2000/svg">
+  <rect x="14" y="16" width="68" height="64" rx="12" fill="#dbe7f6" stroke="#497bbd" stroke-width="4"/>
+  <path d="M32 30 H64 L58 46 H38 Z" fill="#497bbd" opacity="0.85"/>
+  <circle cx="48" cy="60" r="14" fill="#7fc280" stroke="#3f7349" stroke-width="3"/>
+  <path d="M48 50 C44 54 42 58 48 66 C54 58 52 54 48 50 Z" fill="#d6f5d0"/>
+</svg>

--- a/PalmQuest/assets/icons/info.svg
+++ b/PalmQuest/assets/icons/info.svg
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="96" height="96" viewBox="0 0 96 96" xmlns="http://www.w3.org/2000/svg">
+  <circle cx="48" cy="48" r="44" fill="#e8f4ff" stroke="#3f6fa0" stroke-width="4"/>
+  <rect x="44" y="36" width="8" height="32" rx="4" fill="#3f6fa0"/>
+  <circle cx="48" cy="28" r="6" fill="#3f6fa0"/>
+</svg>

--- a/PalmQuest/assets/icons/pollination.svg
+++ b/PalmQuest/assets/icons/pollination.svg
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="96" height="96" viewBox="0 0 96 96" xmlns="http://www.w3.org/2000/svg">
+  <circle cx="48" cy="48" r="44" fill="#fef4d7" stroke="#f2b632" stroke-width="4"/>
+  <path d="M48 20 L54 40 L76 40 L58 52 L64 72 L48 60 L32 72 L38 52 L20 40 L42 40 Z" fill="#f2b632" stroke="#cb8e1e" stroke-width="2"/>
+  <circle cx="48" cy="48" r="10" fill="#fff2a1" stroke="#cb8e1e" stroke-width="2"/>
+</svg>

--- a/PalmQuest/assets/icons/production.svg
+++ b/PalmQuest/assets/icons/production.svg
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="96" height="96" viewBox="0 0 96 96" xmlns="http://www.w3.org/2000/svg">
+  <rect x="14" y="18" width="68" height="60" rx="12" fill="#fdf0f5" stroke="#b94e72" stroke-width="4"/>
+  <path d="M24 62 L36 46 L48 54 L60 38 L72 50" fill="none" stroke="#b94e72" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="36" cy="46" r="4" fill="#b94e72"/>
+  <circle cx="48" cy="54" r="4" fill="#b94e72"/>
+  <circle cx="60" cy="38" r="4" fill="#b94e72"/>
+  <path d="M26 70 H70" stroke="#b94e72" stroke-width="4" stroke-linecap="round"/>
+</svg>

--- a/PalmQuest/assets/icons/quiz.svg
+++ b/PalmQuest/assets/icons/quiz.svg
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="96" height="96" viewBox="0 0 96 96" xmlns="http://www.w3.org/2000/svg">
+  <rect x="18" y="12" width="60" height="72" rx="10" fill="#fff6df" stroke="#d18c1d" stroke-width="4"/>
+  <path d="M32 32 H64" stroke="#d18c1d" stroke-width="4" stroke-linecap="round"/>
+  <path d="M32 44 H56" stroke="#d18c1d" stroke-width="4" stroke-linecap="round"/>
+  <path d="M32 56 H52" stroke="#d18c1d" stroke-width="4" stroke-linecap="round"/>
+  <circle cx="48" cy="72" r="8" fill="#d18c1d"/>
+  <text x="48" y="76" font-size="10" text-anchor="middle" fill="#fff" font-family="sans-serif">?</text>
+</svg>

--- a/PalmQuest/assets/icons/timeline.svg
+++ b/PalmQuest/assets/icons/timeline.svg
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="96" height="96" viewBox="0 0 96 96" xmlns="http://www.w3.org/2000/svg">
+  <rect x="12" y="24" width="72" height="48" rx="10" fill="#fff" stroke="#4f9d69" stroke-width="4"/>
+  <polyline points="20,52 36,40 52,48 68,34 76,42" fill="none" stroke="#4f9d69" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="36" cy="40" r="4" fill="#4f9d69"/>
+  <circle cx="52" cy="48" r="4" fill="#4f9d69"/>
+  <circle cx="68" cy="34" r="4" fill="#4f9d69"/>
+  <path d="M24 66 H72" stroke="#4f9d69" stroke-width="4" stroke-linecap="round"/>
+</svg>

--- a/PalmQuest/data/glossary.json
+++ b/PalmQuest/data/glossary.json
@@ -1,0 +1,14 @@
+{
+  "terms": {
+    "FFB": "Fresh Fruit Bunch harvested from oil palms; it contains numerous fruitlets rich in oil.",
+    "OER": "Oil Extraction Rate, the percentage of oil recovered from processed fresh fruit bunches.",
+    "Nursery": "Early growth area where germinated seedlings develop under shade before field transplanting.",
+    "Rachis": "The central stalk of a frond from which leaflets emerge; keeping it healthy supports photosynthesis.",
+    "Anthesis": "The flowering period when inflorescences open and become receptive or shed pollen.",
+    "Dolomite": "A liming material supplying calcium and magnesium, used to raise acidic soil pH.",
+    "Elaeidobius": "A genus of weevils that naturally pollinate oil palms, often reared for assisted pollination.",
+    "Loose Fruit": "Fruitlets detached from a bunch, signalling ripeness for optimal harvest timing.",
+    "CPO": "Crude Palm Oil, the primary product extracted from oil palm fruit mesocarp.",
+    "PKO": "Palm Kernel Oil, extracted from the seed kernel and traded separately from CPO."
+  }
+}

--- a/PalmQuest/data/hotspots.json
+++ b/PalmQuest/data/hotspots.json
@@ -1,0 +1,204 @@
+{
+  "hotspots": [
+    {
+      "id": "pollination_female",
+      "zone": "pollination",
+      "title": "Female Inflorescence Ready",
+      "text": "The female inflorescence blooms for just two dawns; receptive stigmas glisten when humidity stays high. Trainees note this golden window and deploy pollinating weevils before mid-morning heat lowers success.",
+      "icon": "res://assets/icons/pollination.svg",
+      "position": [8.5, 0.5, 6.2],
+      "mini_game_id": "pollination_catcher",
+      "gallery": []
+    },
+    {
+      "id": "pollination_male",
+      "zone": "pollination",
+      "title": "Male Spikelet Stage",
+      "text": "Male spikelets shed pollen clouds for roughly 36 hours. Freshly opened stamens smell sweet and attract Elaeidobius weevils. Record the start time here to sync your release of collected pollen for controlled trials.",
+      "icon": "res://assets/icons/pollination.svg",
+      "position": [4.0, 0.5, -3.5],
+      "mini_game_id": "pollination_catcher",
+      "gallery": []
+    },
+    {
+      "id": "pollination_beetle",
+      "zone": "pollination",
+      "title": "Pollinator Shelter Box",
+      "text": "Rearing boxes keep beetles shaded, hydrated, and dust-free. Inspect humidity pads and replace fermenting fruit bait daily so released weevils stay vigorous enough to navigate dense frond canopies.",
+      "icon": "res://assets/icons/pollination.svg",
+      "position": [1.0, 0.5, 10.0],
+      "mini_game_id": "pollination_catcher",
+      "gallery": []
+    },
+    {
+      "id": "pollination_weather",
+      "zone": "pollination",
+      "title": "Weather Alert Kiosk",
+      "text": "Light rain helps pollen adhere, while downpours wash grains away. Track dawn dew points here and postpone releases if winds exceed 10 km/h; gusts scatter beetles and reduce visits per female spikelet.",
+      "icon": "res://assets/icons/pollination.svg",
+      "position": [-5.5, 0.5, 2.0],
+      "mini_game_id": null,
+      "gallery": []
+    },
+    {
+      "id": "pollination_timeline",
+      "zone": "pollination",
+      "title": "Anthesis Planner Board",
+      "text": "Use the planner to log anthesis stages: pre-opening, receptive, and senescent. Monitoring three days in advance ensures your pollination crews rotate efficiently between blocks without missing peak bloom.",
+      "icon": "res://assets/icons/pollination.svg",
+      "position": [-2.0, 0.5, -6.5],
+      "mini_game_id": null,
+      "gallery": []
+    },
+    {
+      "id": "fertilizer_station",
+      "zone": "fertilization",
+      "title": "Bulk Blend Mixer",
+      "text": "Blend water-soluble urea with muriate of potash in equal bands for palms four to six years old. Target 0.8 kg per palm split thrice yearly and adjust when leaf analysis shows nitrogen above 2.8%.",
+      "icon": "res://assets/icons/fertilizer.svg",
+      "position": [14.0, 0.5, -4.0],
+      "mini_game_id": "fertilizer_mixer",
+      "gallery": []
+    },
+    {
+      "id": "fertilizer_acidity",
+      "zone": "fertilization",
+      "title": "Soil Acidity Probe",
+      "text": "Lateritic soils drift acidic; keep pH near 5.0. This probe logs readings and recommends dolomite at 1.5 t/ha if pH drops below 4.5, protecting root uptake of potassium and magnesium.",
+      "icon": "res://assets/icons/fertilizer.svg",
+      "position": [18.0, 0.5, 2.5],
+      "mini_game_id": null,
+      "gallery": []
+    },
+    {
+      "id": "fertilizer_rain",
+      "zone": "fertilization",
+      "title": "Rainfall Radar Drum",
+      "text": "Nutrient efficiency sinks when heavy rain arrives within six hours of application. Check the radar drum for approaching storms; if the gauge expects 15 mm or more, reschedule to conserve inputs.",
+      "icon": "res://assets/icons/fertilizer.svg",
+      "position": [11.5, 0.5, 6.0],
+      "mini_game_id": null,
+      "gallery": []
+    },
+    {
+      "id": "fertilizer_leaf_sample",
+      "zone": "fertilization",
+      "title": "Frond 17 Sampling Rack",
+      "text": "Tissue sampling from frond 17 shows seasonal nutrient status. This rack teaches proper leaflet selection, drying, and labeling steps so lab diagnostics translate to precise fertilizer prescriptions.",
+      "icon": "res://assets/icons/fertilizer.svg",
+      "position": [16.5, 0.5, 9.0],
+      "mini_game_id": "fertilizer_mixer",
+      "gallery": []
+    },
+    {
+      "id": "fertilizer_safety",
+      "zone": "fertilization",
+      "title": "Protective Gear Locker",
+      "text": "Always issue gloves, respirators, and eye shields when handling dustier compound fertilizers. Inspect storage for clumped material that signals moisture ingress and degraded nutrient concentration.",
+      "icon": "res://assets/icons/fertilizer.svg",
+      "position": [9.0, 0.5, 11.0],
+      "mini_game_id": null,
+      "gallery": []
+    },
+    {
+      "id": "timeline_nursery",
+      "zone": "timeline",
+      "title": "Nursery Germination Beds",
+      "text": "Seeds soak, preheat, and sprout under shade nets for 90 days. Rotate trays weekly to maintain even moisture, and discard seedlings lacking a straight plumule to keep future field stands uniform.",
+      "icon": "res://assets/icons/timeline.svg",
+      "position": [-12.0, 0.5, -10.5],
+      "mini_game_id": null,
+      "gallery": []
+    },
+    {
+      "id": "timeline_field_planting",
+      "zone": "timeline",
+      "title": "Immature Field Plot",
+      "text": "Transplanting occurs at 10 to 12 months when seedlings show 5 to 7 fronds. Align palms on equilateral triangles 9 meters apart and mulch generously to suppress weeds during juvenile growth.",
+      "icon": "res://assets/icons/timeline.svg",
+      "position": [-16.0, 0.5, -2.0],
+      "mini_game_id": "harvest_timing",
+      "gallery": []
+    },
+    {
+      "id": "timeline_pruning",
+      "zone": "timeline",
+      "title": "Pruning Workshop",
+      "text": "Proper pruning removes senescent fronds just below fresh fruit bunches. Follow the clock-face method to retain 40 functional fronds; this maintains photosynthetic area and lowers pest harbors.",
+      "icon": "res://assets/icons/timeline.svg",
+      "position": [-9.0, 0.5, -14.0],
+      "mini_game_id": null,
+      "gallery": []
+    },
+    {
+      "id": "timeline_harvest",
+      "zone": "timeline",
+      "title": "Harvest Cycle Briefing",
+      "text": "Palms enter steady production around year four. Schedule harvest rounds every 10 to 12 days, targeting bunches with 1 to 2 loose fruits on the ground to balance oil quality and yield.",
+      "icon": "res://assets/icons/timeline.svg",
+      "position": [-20.0, 0.5, -6.0],
+      "mini_game_id": "harvest_timing",
+      "gallery": []
+    },
+    {
+      "id": "timeline_processing",
+      "zone": "timeline",
+      "title": "Field Evacuation Depot",
+      "text": "Fresh fruit bunches must reach the mill within 24 hours to prevent free fatty acid spikes. Learn stacking patterns that keep bunches aerated and ready for evacuation trolleys.",
+      "icon": "res://assets/icons/timeline.svg",
+      "position": [-14.0, 0.5, -18.0],
+      "mini_game_id": null,
+      "gallery": []
+    },
+    {
+      "id": "production_dashboard",
+      "zone": "production",
+      "title": "Production Dashboard Hut",
+      "text": "This hut visualizes yields, oil extraction rates, and palm age distribution. Unlock it by earning badges from every zone and explore interactive charts that project monthly revenue versus targets.",
+      "icon": "res://assets/icons/dashboard.svg",
+      "position": [0.0, 0.5, -18.0],
+      "mini_game_id": null,
+      "gallery": []
+    },
+    {
+      "id": "production_ffb",
+      "zone": "production",
+      "title": "FFB Grading Station",
+      "text": "Inspect bunch size, fruitlet density, and bruise percentage to classify FFB quality. Accurate grading rewards harvesters and feeds reliable input for mill oil extraction calculations.",
+      "icon": "res://assets/icons/production.svg",
+      "position": [6.0, 0.5, -20.0],
+      "mini_game_id": null,
+      "gallery": []
+    },
+    {
+      "id": "production_prices",
+      "zone": "production",
+      "title": "Price Board",
+      "text": "Daily commodity updates pair crude palm oil prices with palm kernel oil benchmarks. Compare them against operating costs to decide when to accelerate harvesting or hold matured fields briefly.",
+      "icon": "res://assets/icons/production.svg",
+      "position": [-6.0, 0.5, -22.0],
+      "mini_game_id": null,
+      "gallery": []
+    },
+    {
+      "id": "production_oer",
+      "zone": "production",
+      "title": "OER Benchmark Poster",
+      "text": "Oil extraction rate targets hover near 21%. This poster shows how fruit ripeness, sterilizer steam, and threshing efficiency interact. Note how poor field sanitation elevates FFA and lowers OER.",
+      "icon": "res://assets/icons/production.svg",
+      "position": [10.0, 0.5, -24.0],
+      "mini_game_id": null,
+      "gallery": []
+    },
+    {
+      "id": "production_records",
+      "zone": "production",
+      "title": "Yield Records Desk",
+      "text": "Digital logbooks compare current block yields with five-year averages. Enter today's harvested tonnage to reveal alerts if productivity dips more than 8% from climatic-adjusted expectations.",
+      "icon": "res://assets/icons/production.svg",
+      "position": [-10.0, 0.5, -18.5],
+      "mini_game_id": null,
+      "gallery": []
+    }
+  ]
+}

--- a/PalmQuest/data/minigames.json
+++ b/PalmQuest/data/minigames.json
@@ -1,0 +1,29 @@
+{
+  "mini_games": {
+    "pollination_catcher": {
+      "name": "Pollination Catcher",
+      "time_limit": 45,
+      "target_score": 25,
+      "spawn_interval": 0.8,
+      "optimal_window_start": 5,
+      "optimal_window_end": 30,
+      "description": "Move the collection net to capture as many pollen-carrying beetles as possible during the receptive window."
+    },
+    "fertilizer_mixer": {
+      "name": "Fertilizer Mixer",
+      "time_limit": 60,
+      "target_kg_per_ha": 160,
+      "tolerance": 8,
+      "bag_sizes": [10, 15, 20, 25],
+      "description": "Drag fertilizer bags until the combined dosage meets the target rate without exceeding tolerance."
+    },
+    "harvest_timing": {
+      "name": "Harvest Timing",
+      "time_limit": 50,
+      "target_accuracy": 0.85,
+      "max_bunches": 12,
+      "loose_fruit_threshold": 2,
+      "description": "Select ripe bunches showing the right color and loose fruit count while avoiding under- or overripe bunches."
+    }
+  }
+}

--- a/PalmQuest/data/production_demo.json
+++ b/PalmQuest/data/production_demo.json
@@ -1,0 +1,21 @@
+{
+  "monthly": [
+    {"month": "Jan", "ffb_tonnes": 420, "oer_percent": 21.2, "cpo_price_usd": 930},
+    {"month": "Feb", "ffb_tonnes": 410, "oer_percent": 20.9, "cpo_price_usd": 915},
+    {"month": "Mar", "ffb_tonnes": 445, "oer_percent": 21.4, "cpo_price_usd": 940},
+    {"month": "Apr", "ffb_tonnes": 460, "oer_percent": 21.0, "cpo_price_usd": 925},
+    {"month": "May", "ffb_tonnes": 472, "oer_percent": 21.6, "cpo_price_usd": 950},
+    {"month": "Jun", "ffb_tonnes": 465, "oer_percent": 21.3, "cpo_price_usd": 942},
+    {"month": "Jul", "ffb_tonnes": 458, "oer_percent": 21.1, "cpo_price_usd": 938},
+    {"month": "Aug", "ffb_tonnes": 470, "oer_percent": 21.5, "cpo_price_usd": 948},
+    {"month": "Sep", "ffb_tonnes": 455, "oer_percent": 21.0, "cpo_price_usd": 932},
+    {"month": "Oct", "ffb_tonnes": 480, "oer_percent": 21.7, "cpo_price_usd": 955},
+    {"month": "Nov", "ffb_tonnes": 492, "oer_percent": 21.8, "cpo_price_usd": 960},
+    {"month": "Dec", "ffb_tonnes": 505, "oer_percent": 22.0, "cpo_price_usd": 968}
+  ],
+  "targets": {
+    "ffb_tonnes": 460,
+    "oer_percent": 21.2,
+    "cpo_price_usd": 940
+  }
+}

--- a/PalmQuest/data/quizzes.json
+++ b/PalmQuest/data/quizzes.json
@@ -1,0 +1,168 @@
+{
+  "zones": {
+    "pollination": {
+      "title": "Pollination Zone Quiz",
+      "pass_score": 4,
+      "questions": [
+        {
+          "id": "pollination_window",
+          "prompt": "How long does a female inflorescence remain receptive to effective pollination?",
+          "options": ["About 12 hours", "Around two dawns", "A full week", "Until the next pruning round"],
+          "correct_index": 1,
+          "explanation": "Female inflorescences present receptive stigmas for roughly two dawn periods, making timing critical."
+        },
+        {
+          "id": "pollination_weather",
+          "prompt": "Why should releases be postponed when strong winds are forecast?",
+          "options": ["Wind reduces pollen viability", "Beetles are blown away from target palms", "Wind removes protective wax", "Wind raises humidity too high"],
+          "correct_index": 1,
+          "explanation": "Gusts above 10 km/h scatter the weevils, leading to fewer visits per female spikelet."
+        },
+        {
+          "id": "pollination_male_stage",
+          "prompt": "What signals the start of peak pollen shed on male spikelets?",
+          "options": ["When spikelets turn brown", "When stamens release a sweet scent", "When fronds droop", "After sunset"],
+          "correct_index": 1,
+          "explanation": "Freshly opened stamens emit a sweet smell and begin shedding pollen for about 36 hours."
+        },
+        {
+          "id": "pollination_log",
+          "prompt": "Why log anthesis stages three days in advance?",
+          "options": ["To estimate fertilizer use", "To coordinate crew rotations", "To plan pesticide spraying", "To set irrigation schedules"],
+          "correct_index": 1,
+          "explanation": "Knowing which blocks will peak soon helps crews rotate efficiently without missing receptive blooms."
+        },
+        {
+          "id": "pollination_beetle_care",
+          "prompt": "How are beetle rearing boxes kept effective?",
+          "options": ["By storing them in direct sun", "By replacing bait daily and keeping them humid", "By sealing air vents", "By freezing them overnight"],
+          "correct_index": 1,
+          "explanation": "Shaded, humid boxes with fresh bait keep weevils active for release."
+        }
+      ]
+    },
+    "fertilization": {
+      "title": "Fertilization Zone Quiz",
+      "pass_score": 4,
+      "questions": [
+        {
+          "id": "fertilizer_split",
+          "prompt": "How often should the 0.8 kg per palm fertilizer mix be applied?",
+          "options": ["Once yearly", "Twice yearly", "Three times yearly", "Monthly"],
+          "correct_index": 2,
+          "explanation": "Split the dosage into three rounds to align with nutrient demand and reduce leaching."
+        },
+        {
+          "id": "fertilizer_ph",
+          "prompt": "At what soil pH should dolomite be recommended?",
+          "options": ["Above 5.5", "Between 5.0 and 5.5", "Below 4.5", "Exactly 6.0"],
+          "correct_index": 2,
+          "explanation": "Dolomite at 1.5 t/ha helps when pH dips below 4.5 to buffer acidity."
+        },
+        {
+          "id": "fertilizer_rain",
+          "prompt": "Why avoid fertilizing before heavy rain?",
+          "options": ["It makes palms grow too fast", "Nutrients leach away reducing efficiency", "It causes fronds to burn", "It attracts pests"],
+          "correct_index": 1,
+          "explanation": "Rain above 15 mm soon after application washes nutrients away before roots can use them."
+        },
+        {
+          "id": "fertilizer_leaf",
+          "prompt": "Which frond is sampled for tissue analysis?",
+          "options": ["Frond 1", "Frond 9", "Frond 17", "Frond 33"],
+          "correct_index": 2,
+          "explanation": "Frond 17 provides consistent, comparable nutrient readings across palms."
+        },
+        {
+          "id": "fertilizer_safety",
+          "prompt": "What should be checked in the protective gear locker?",
+          "options": ["Fuel inventory", "Moisture damage on stored fertilizers", "Tool calibration", "Seedling inventory"],
+          "correct_index": 1,
+          "explanation": "Clumped or damp fertilizer indicates moisture ingress, lowering nutrient quality."
+        }
+      ]
+    },
+    "timeline": {
+      "title": "Cultivation Timeline Quiz",
+      "pass_score": 4,
+      "questions": [
+        {
+          "id": "timeline_nursery",
+          "prompt": "How long do seedlings typically stay under shade nets?",
+          "options": ["30 days", "60 days", "90 days", "120 days"],
+          "correct_index": 2,
+          "explanation": "Nursery seedlings remain under shade nets for about 90 days before shifting."
+        },
+        {
+          "id": "timeline_transplant",
+          "prompt": "When are seedlings field transplanted?",
+          "options": ["At 3 months with 2 fronds", "At 6 months with 4 fronds", "At 10–12 months with 5–7 fronds", "At 18 months with 10 fronds"],
+          "correct_index": 2,
+          "explanation": "Ideal field planting occurs at 10–12 months when palms show 5–7 healthy fronds."
+        },
+        {
+          "id": "timeline_spacing",
+          "prompt": "What spacing pattern keeps palms evenly distributed?",
+          "options": ["Rectangular 6 m x 9 m", "Equilateral triangles 9 m apart", "Row spacing 12 m", "Random holes"],
+          "correct_index": 1,
+          "explanation": "Equilateral triangles spaced 9 m apart optimize light capture and accessibility."
+        },
+        {
+          "id": "timeline_pruning",
+          "prompt": "Why maintain about 40 functional fronds?",
+          "options": ["To reduce height", "To maintain photosynthetic area and reduce pests", "To increase windbreak", "To ease irrigation"],
+          "correct_index": 1,
+          "explanation": "Proper pruning preserves photosynthesis and limits pest harbors."
+        },
+        {
+          "id": "timeline_harvest",
+          "prompt": "Which cue indicates a bunch is ready to harvest?",
+          "options": ["No loose fruits", "One or two loose fruits on the ground", "All fruits still green", "The bunch has dried"],
+          "correct_index": 1,
+          "explanation": "1–2 loose fruits on the ground signal ripe bunches with optimal oil recovery."
+        }
+      ]
+    },
+    "production": {
+      "title": "Production & Prices Quiz",
+      "pass_score": 4,
+      "questions": [
+        {
+          "id": "production_ffb",
+          "prompt": "What does FFB stand for?",
+          "options": ["Fresh Fruit Bunch", "Fertilizer Field Balance", "Frond Fiber Bulk", "Field Fuel Barrel"],
+          "correct_index": 0,
+          "explanation": "FFB refers to Fresh Fruit Bunch, the harvested unit sent to the mill."
+        },
+        {
+          "id": "production_oer",
+          "prompt": "What is a typical target for oil extraction rate (OER)?",
+          "options": ["10%", "15%", "21%", "35%"],
+          "correct_index": 2,
+          "explanation": "Operations often target OER around 21% for efficient processing."
+        },
+        {
+          "id": "production_pricing",
+          "prompt": "Why compare CPO and PKO prices on the board?",
+          "options": ["To set irrigation schedules", "To decide when to accelerate or slow harvesting", "To plan fertilizer blending", "To adjust worker shifts"],
+          "correct_index": 1,
+          "explanation": "Price comparisons help determine whether to harvest aggressively or delay briefly."
+        },
+        {
+          "id": "production_records",
+          "prompt": "What happens if yield dips more than 8% from expectations?",
+          "options": ["An alert is shown for investigation", "Palms are automatically pruned", "Fertilizer is reduced", "The mill shuts down"],
+          "correct_index": 0,
+          "explanation": "The dashboard alerts managers to investigate productivity shortfalls."
+        },
+        {
+          "id": "production_time",
+          "prompt": "Why must FFB reach the mill within 24 hours?",
+          "options": ["To avoid weight loss", "To reduce transport costs", "To prevent free fatty acid spikes", "To align with labor shifts"],
+          "correct_index": 2,
+          "explanation": "Delays increase free fatty acids, reducing oil quality and yield."
+        }
+      ]
+    }
+  }
+}

--- a/PalmQuest/default_env.tres
+++ b/PalmQuest/default_env.tres
@@ -1,0 +1,20 @@
+[gd_resource type="Environment" load_steps=2 format=3]
+
+[sub_resource type="Sky" id="1"]
+sky_material = SubResource(2)
+
+[sub_resource type="ProceduralSkyMaterial" id="2"]
+sky_top_color = Color(0.223529, 0.490196, 0.705882, 1)
+sky_horizon_color = Color(0.717647, 0.843137, 0.937255, 1)
+
+glow_enabled = true
+
+[resource]
+background_mode = 2
+sky = SubResource(1)
+ambient_light_source = 1
+ambient_light_color = Color(0.807843, 0.854902, 0.870588, 1)
+ambient_light_energy = 0.75
+fog_enabled = true
+fog_light_color = Color(0.815686, 0.87451, 0.843137, 1)
+fog_density = 0.0025

--- a/PalmQuest/icon.svg
+++ b/PalmQuest/icon.svg
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg width="128" height="128" viewBox="0 0 128 128" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#d7f3dd"/>
+      <stop offset="100%" stop-color="#78c496"/>
+    </linearGradient>
+  </defs>
+  <rect width="128" height="128" rx="16" ry="16" fill="url(#bg)"/>
+  <g transform="translate(64 64)">
+    <path d="M0 -32 C-18 -24 -28 -4 -12 6 C-26 12 -26 30 -4 28 C-4 32 0 48 0 48 C0 48 4 32 4 28 C26 30 26 12 12 6 C28 -4 18 -24 0 -32 Z" fill="#3b7d4b"/>
+    <circle cx="0" cy="-12" r="6" fill="#f4d35e"/>
+  </g>
+</svg>

--- a/PalmQuest/project.godot
+++ b/PalmQuest/project.godot
@@ -1,0 +1,39 @@
+; Engine configuration file.
+; It's best edited using the editor UI and not directly,
+; since the parameters that go here are not all obvious.
+;
+; Format:
+;   [section]
+;   param=value
+;
+config_version=5
+
+[application]
+config/name="PalmQuest"
+run/main_scene="res://scenes/Main.tscn"
+config/icon="res://icon.svg"
+
+[display]
+window/size/width=1280
+window/size/height=720
+window/stretch/mode="viewport"
+window/stretch/aspect="keep"
+
+[rendering]
+quality/driver/driver_name="gl_compatibility"
+
+[input]
+move_forward={"deadzone":0.5,"events":[{"type":"joy_axis","axis":1,"device":0,"deadzone":0.5,"direction":-1},{"type":"key","keycode":87}]}
+move_back={"deadzone":0.5,"events":[{"type":"joy_axis","axis":1,"device":0,"deadzone":0.5,"direction":1},{"type":"key","keycode":83}]}
+move_left={"deadzone":0.5,"events":[{"type":"joy_axis","axis":0,"device":0,"deadzone":0.5,"direction":-1},{"type":"key","keycode":65}]}
+move_right={"deadzone":0.5,"events":[{"type":"joy_axis","axis":0,"device":0,"deadzone":0.5,"direction":1},{"type":"key","keycode":68}]}
+move_up={"deadzone":0.5,"events":[{"type":"key","keycode":32}]}
+sprint={"deadzone":0.5,"events":[{"type":"key","keycode":16777237}]}
+interact={"deadzone":0.5,"events":[{"type":"key","keycode":69}]}
+pause_menu={"deadzone":0.5,"events":[{"type":"key","keycode":16777217}]}
+open_dashboard={"deadzone":0.5,"events":[{"type":"key","keycode":80}]}
+
+[autoload]
+GameState="*res://scripts/singletons/game_state.gd"
+DataService="*res://scripts/singletons/data_service.gd"
+AudioService="*res://scripts/singletons/audio_service.gd"

--- a/PalmQuest/scenes/Hotspot.tscn
+++ b/PalmQuest/scenes/Hotspot.tscn
@@ -1,0 +1,45 @@
+[gd_scene load_steps=5 format=3]
+
+[ext_resource type="Script" path="res://scripts/hotspot.gd" id="1"]
+
+[sub_resource type="SphereShape3D" id="1"]
+radius = 1.6
+
+[sub_resource type="CylinderMesh" id="2"]
+height = 2.5
+radius = 0.5
+
+[sub_resource type="StandardMaterial3D" id="3"]
+albedo_color = Color(0.2, 0.6, 0.2, 0.3)
+emission_enabled = true
+emission = Color(0.2, 0.7, 0.3)
+emission_energy = 1.5
+
+[node name="Hotspot" type="Area3D"]
+script = ExtResource("1")
+monitorable = true
+
+[node name="CollisionShape3D" type="CollisionShape3D" parent="."]
+shape = SubResource("1")
+
+[node name="GlowMesh" type="MeshInstance3D" parent="."]
+mesh = SubResource("2")
+material_override = SubResource("3")
+transform = Transform3D(Basis(1, 0, 0, 0, 0.707107, 0.707107, 0, -0.707107, 0.707107), Vector3(0, 1.25, 0))
+
+[node name="Billboard" type="Node3D" parent="."]
+transform = Transform3D(Basis(1, 0, 0, 0, 1, 0, 0, 0, 1), Vector3(0, 2.0, 0))
+
+[node name="Label3D" type="Label3D" parent="Billboard"]
+text = "Hotspot"
+billboard = 1
+vertical_alignment = 2
+modulate = Color(0.95, 0.95, 0.95, 1)
+
+[node name="Prompt" type="Label3D" parent="Billboard"]
+transform = Transform3D(Basis(1, 0, 0, 0, 1, 0, 0, 0, 1), Vector3(0, -0.5, 0))
+text = "Press E"
+billboard = 1
+visible = false
+modulate = Color(0.9, 0.7, 0.2, 1)
+

--- a/PalmQuest/scenes/Main.tscn
+++ b/PalmQuest/scenes/Main.tscn
@@ -1,0 +1,13 @@
+[gd_scene load_steps=4 format=3]
+
+[ext_resource type="PackedScene" path="res://scenes/TrainingPlot.tscn" id="1"]
+[ext_resource type="PackedScene" path="res://scenes/ui/MainHUD.tscn" id="2"]
+[ext_resource type="Script" path="res://scripts/main.gd" id="3"]
+
+[node name="Main" type="Node"]
+script = ExtResource("3")
+
+[node name="TrainingPlot" parent="." instance=ExtResource("1")] 
+
+[node name="MainHUD" parent="." instance=ExtResource("2")] 
+

--- a/PalmQuest/scenes/Player.tscn
+++ b/PalmQuest/scenes/Player.tscn
@@ -1,0 +1,32 @@
+[gd_scene load_steps=5 format=3]
+
+[ext_resource type="Script" path="res://scripts/player.gd" id="1"]
+
+[sub_resource type="CapsuleShape3D" id="1"]
+radius = 0.4
+height = 1.6
+
+[sub_resource type="StandardMaterial3D" id="2"]
+albedo_color = Color(0.35, 0.55, 0.3, 1)
+
+[sub_resource type="CapsuleMesh" id="3"]
+radius = 0.3
+height = 1.4
+
+[node name="Player" type="CharacterBody3D"]
+script = ExtResource("1")
+
+[node name="CollisionShape3D" type="CollisionShape3D" parent="."]
+transform = Transform3D(Basis(), Vector3(0, 0.9, 0))
+shape = SubResource("1")
+
+[node name="MeshInstance3D" type="MeshInstance3D" parent="."]
+mesh = SubResource("3")
+material_override = SubResource("2")
+transform = Transform3D(Basis(), Vector3(0, 0.9, 0))
+
+[node name="Camera3D" type="Camera3D" parent="."]
+transform = Transform3D(Basis(1, 0, 0, 0, 1, 0, 0, 0, 1), Vector3(0, 1.6, 0))
+current = true
+fov = 70.0
+

--- a/PalmQuest/scenes/TrainingPlot.tscn
+++ b/PalmQuest/scenes/TrainingPlot.tscn
@@ -1,0 +1,76 @@
+[gd_scene load_steps=9 format=3]
+
+[ext_resource type="PackedScene" path="res://scenes/Player.tscn" id="1"]
+[ext_resource type="Script" path="res://scripts/hotspot_manager.gd" id="2"]
+[ext_resource type="PackedScene" path="res://scenes/Hotspot.tscn" id="3"]
+[ext_resource type="Environment" path="res://default_env.tres" id="4"]
+[ext_resource type="Script" path="res://scripts/palm_rows.gd" id="5"]
+
+[sub_resource type="PlaneMesh" id="1"]
+size = Vector2(120, 120)
+
+[sub_resource type="StandardMaterial3D" id="2"]
+albedo_color = Color(0.63, 0.72, 0.52, 1)
+uv1_scale = Vector3(12, 12, 12)
+roughness = 1.0
+
+[sub_resource type="StandardMaterial3D" id="3"]
+albedo_color = Color(0.4, 0.25, 0.15, 1)
+
+[sub_resource type="CylinderMesh" id="4"]
+height = 6.0
+radius = 0.3
+
+[sub_resource type="SphereMesh" id="5"]
+radius = 1.6
+
+[node name="TrainingPlot" type="Node3D"]
+
+[node name="WorldEnvironment" type="WorldEnvironment" parent="."]
+environment = ExtResource("4")
+
+[node name="DirectionalLight3D" type="DirectionalLight3D" parent="."]
+transform = Transform3D(Basis(0.866025, -0.353553, -0.353553, 0, 0.707107, -0.707107, 0.5, 0.612372, 0.612372), Vector3(0, 18, 0))
+light_energy = 1.1
+shadow_enabled = true
+
+[node name="Ground" type="MeshInstance3D" parent="."]
+mesh = SubResource("1")
+material_override = SubResource("2")
+
+[node name="Player" parent="." instance=ExtResource("1")]
+transform = Transform3D(Basis(), Vector3(0, 0, 4))
+
+[node name="HotspotManager" type="Node3D" parent="."]
+script = ExtResource("2")
+hotspot_scene = ExtResource("3")
+
+[node name="PalmRows" type="MultiMeshInstance3D" parent="."]
+script = ExtResource("5")
+
+[node name="ZoneMarkers" type="Node3D" parent="."]
+
+[node name="Pollination" type="Label3D" parent="ZoneMarkers"]
+transform = Transform3D(Basis(), Vector3(6, 2.5, 8))
+text = "Pollination Zone"
+billboard = 1
+modulate = Color(0.95, 0.85, 0.4, 1)
+
+[node name="Fertilization" type="Label3D" parent="ZoneMarkers"]
+transform = Transform3D(Basis(), Vector3(15, 2.5, 4))
+text = "Fertilization Zone"
+billboard = 1
+modulate = Color(0.7, 0.8, 0.95, 1)
+
+[node name="Timeline" type="Label3D" parent="ZoneMarkers"]
+transform = Transform3D(Basis(), Vector3(-14, 2.5, -8))
+text = "Cultivation Timeline"
+billboard = 1
+modulate = Color(0.9, 0.7, 0.6, 1)
+
+[node name="Production" type="Label3D" parent="ZoneMarkers"]
+transform = Transform3D(Basis(), Vector3(0, 2.5, -16))
+text = "Production & Prices"
+billboard = 1
+modulate = Color(0.8, 0.9, 0.8, 1)
+

--- a/PalmQuest/scenes/mini_games/FertilizerGame.tscn
+++ b/PalmQuest/scenes/mini_games/FertilizerGame.tscn
@@ -1,0 +1,53 @@
+[gd_scene load_steps=3 format=3]
+
+[ext_resource type="Script" path="res://scripts/mini_games/fertilizer_game.gd" id="1"]
+
+[node name="FertilizerGame" type="Control"]
+anchors_preset = 8
+anchor_right = 1.0
+anchor_bottom = 1.0
+script = ExtResource("1")
+
+[node name="Panel" type="Panel" parent="."]
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+custom_minimum_size = Vector2(600, 320)
+
+[node name="Info" type="VBoxContainer" parent="Panel"]
+anchors_preset = 1
+anchor_right = 1.0
+custom_minimum_size = Vector2(0, 80)
+
+[node name="TotalLabel" type="Label" parent="Panel/Info"]
+text = "Total: 0 kg/ha"
+
+[node name="Feedback" type="Label" parent="Panel/Info"]
+text = ""
+
+[node name="Bags" type="HBoxContainer" parent="Panel"]
+anchors_preset = 5
+anchor_top = 0.3
+anchor_bottom = 0.55
+anchor_right = 1.0
+custom_constants/separation = 12
+
+[node name="Selections" type="VBoxContainer" parent="Panel"]
+anchors_preset = 9
+anchor_top = 0.55
+anchor_bottom = 1.0
+anchor_right = 1.0
+custom_constants/separation = 8
+
+[node name="List" type="VBoxContainer" parent="Panel/Selections"]
+size_flags_vertical = 3
+custom_constants/separation = 4
+
+[node name="Buttons" type="HBoxContainer" parent="Panel/Selections"]
+
+[node name="UndoButton" type="Button" parent="Panel/Selections/Buttons"]
+text = "Undo"
+
+[node name="ResetButton" type="Button" parent="Panel/Selections/Buttons"]
+text = "Reset"
+

--- a/PalmQuest/scenes/mini_games/HarvestGame.tscn
+++ b/PalmQuest/scenes/mini_games/HarvestGame.tscn
@@ -1,0 +1,31 @@
+[gd_scene load_steps=3 format=3]
+
+[ext_resource type="Script" path="res://scripts/mini_games/harvest_game.gd" id="1"]
+
+[node name="HarvestGame" type="Control"]
+anchors_preset = 8
+anchor_right = 1.0
+anchor_bottom = 1.0
+script = ExtResource("1")
+
+[node name="Panel" type="Panel" parent="."]
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+custom_minimum_size = Vector2(600, 320)
+
+[node name="Info" type="Label" parent="Panel"]
+anchors_preset = 1
+anchor_right = 1.0
+text = "Select ripe bunches"
+horizontal_alignment = 1
+
+[node name="BunchContainer" type="GridContainer" parent="Panel"]
+anchors_preset = 15
+anchor_top = 0.2
+anchor_right = 1.0
+anchor_bottom = 1.0
+columns = 4
+custom_constants/hseparation = 8
+custom_constants/vseparation = 8
+

--- a/PalmQuest/scenes/mini_games/PollinationGame.tscn
+++ b/PalmQuest/scenes/mini_games/PollinationGame.tscn
@@ -1,0 +1,34 @@
+[gd_scene load_steps=3 format=3]
+
+[ext_resource type="Script" path="res://scripts/mini_games/pollination_game.gd" id="1"]
+
+[node name="PollinationGame" type="Control"]
+anchors_preset = 8
+anchor_right = 1.0
+anchor_bottom = 1.0
+script = ExtResource("1")
+
+[node name="Panel" type="Panel" parent="."]
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+custom_minimum_size = Vector2(600, 320)
+modulate = Color(1, 1, 1, 0.85)
+
+[node name="Net" type="ColorRect" parent="Panel"]
+color = Color(0.9, 0.9, 0.1, 0.8)
+size = Vector2(80, 40)
+position = Vector2(240, 200)
+
+[node name="Beetles" type="Node" parent="Panel"]
+
+[node name="Info" type="Label" parent="Panel"]
+text = "Catch beetles"
+anchors_preset = 1
+anchor_left = 0.0
+anchor_top = 0.0
+anchor_right = 1.0
+anchor_bottom = 0.0
+custom_minimum_size = Vector2(0, 28)
+horizontal_alignment = 1
+

--- a/PalmQuest/scenes/ui/DashboardPanel.tscn
+++ b/PalmQuest/scenes/ui/DashboardPanel.tscn
@@ -1,0 +1,61 @@
+[gd_scene load_steps=4 format=3]
+
+[ext_resource type="Script" path="res://scripts/ui/dashboard_panel.gd" id="1"]
+[ext_resource type="Script" path="res://scripts/ui/production_chart.gd" id="2"]
+
+[node name="DashboardPanel" type="Control"]
+anchors_preset = 8
+anchor_bottom = 1.0
+anchor_right = 1.0
+visible = false
+script = ExtResource("1")
+
+[node name="MarginContainer" type="MarginContainer" parent="."]
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+custom_constants/margin_left = 48
+custom_constants/margin_right = 48
+custom_constants/margin_top = 48
+custom_constants/margin_bottom = 48
+
+[node name="VBoxContainer" type="VBoxContainer" parent="MarginContainer"]
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+
+[node name="Header" type="HBoxContainer" parent="MarginContainer/VBoxContainer"]
+custom_minimum_size = Vector2(0, 40)
+
+[node name="BadgeSummary" type="Label" parent="MarginContainer/VBoxContainer/Header"]
+size_flags_horizontal = 3
+text = "Badges earned: 0"
+
+[node name="CloseButton" type="Button" parent="MarginContainer/VBoxContainer/Header"]
+text = "Close"
+
+[node name="Body" type="VBoxContainer" parent="MarginContainer/VBoxContainer"]
+size_flags_vertical = 3
+custom_constants/separation = 16
+
+[node name="ChartContainer" type="Panel" parent="MarginContainer/VBoxContainer/Body"]
+size_flags_vertical = 3
+custom_minimum_size = Vector2(0, 280)
+
+[node name="ProductionChart" type="Control" parent="MarginContainer/VBoxContainer/Body/ChartContainer"]
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+script = ExtResource("2")
+
+[node name="Summary" type="RichTextLabel" parent="MarginContainer/VBoxContainer/Body"]
+size_flags_vertical = 1
+text = ""
+wrap_mode = 1
+
+[node name="Footer" type="HBoxContainer" parent="MarginContainer/VBoxContainer"]
+visible = false
+
+[node name="CloseButton" type="Button" parent="MarginContainer/VBoxContainer/Footer"]
+text = "Close"
+

--- a/PalmQuest/scenes/ui/HotspotPanel.tscn
+++ b/PalmQuest/scenes/ui/HotspotPanel.tscn
@@ -1,0 +1,61 @@
+[gd_scene load_steps=3 format=3]
+
+[ext_resource type="Script" path="res://scripts/ui/hotspot_panel.gd" id="1"]
+
+[node name="HotspotPanel" type="Control"]
+anchors_preset = 8
+anchor_bottom = 1.0
+anchor_right = 1.0
+offsets = Rect2(0, 0, 0, 0)
+visible = false
+script = ExtResource("1")
+
+[node name="MarginContainer" type="MarginContainer" parent="."]
+anchors_preset = 14
+anchor_left = 0.6
+anchor_right = 0.98
+anchor_top = 0.05
+anchor_bottom = 0.55
+custom_constants/margin_left = 16
+custom_constants/margin_right = 16
+custom_constants/margin_top = 16
+custom_constants/margin_bottom = 16
+
+[node name="VBoxContainer" type="VBoxContainer" parent="MarginContainer"]
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+alignment = 1
+
+[node name="Header" type="HBoxContainer" parent="MarginContainer/VBoxContainer"]
+custom_minimum_size = Vector2(0, 48)
+
+[node name="Icon" type="TextureRect" parent="MarginContainer/VBoxContainer/Header"]
+custom_minimum_size = Vector2(48, 48)
+stretch_mode = 4
+
+[node name="Title" type="Label" parent="MarginContainer/VBoxContainer/Header"]
+size_flags_horizontal = 3
+text = "Hotspot"
+uppercase = true
+
+[node name="CloseButton" type="Button" parent="MarginContainer/VBoxContainer/Header"]
+text = "Close"
+
+[node name="Body" type="VBoxContainer" parent="MarginContainer/VBoxContainer"]
+size_flags_vertical = 3
+
+[node name="Text" type="RichTextLabel" parent="MarginContainer/VBoxContainer/Body"]
+size_flags_vertical = 3
+text = "Hotspot details go here."
+wrap_mode = 1
+
+[node name="Actions" type="HBoxContainer" parent="MarginContainer/VBoxContainer"]
+alignment = 1
+
+[node name="MiniGameButton" type="Button" parent="MarginContainer/VBoxContainer/Actions"]
+text = "Try Mini-Game"
+
+[node name="QuizButton" type="Button" parent="MarginContainer/VBoxContainer/Actions"]
+text = "Open Zone Quiz"
+

--- a/PalmQuest/scenes/ui/MainHUD.tscn
+++ b/PalmQuest/scenes/ui/MainHUD.tscn
@@ -1,0 +1,70 @@
+[gd_scene load_steps=6 format=3]
+
+[ext_resource type="Script" path="res://scripts/ui/main_hud.gd" id="1"]
+[ext_resource type="PackedScene" path="res://scenes/ui/HotspotPanel.tscn" id="2"]
+[ext_resource type="PackedScene" path="res://scenes/ui/MiniGamePanel.tscn" id="3"]
+[ext_resource type="PackedScene" path="res://scenes/ui/QuizPanel.tscn" id="4"]
+[ext_resource type="PackedScene" path="res://scenes/ui/DashboardPanel.tscn" id="5"]
+
+[node name="MainHUD" type="CanvasLayer"]
+script = ExtResource("1")
+
+[node name="Control" type="Control" parent="."]
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+
+[node name="Prompt" type="Label" parent="Control"]
+anchors_preset = 1
+anchor_right = 1.0
+text = "Press E to inspect"
+horizontal_alignment = 1
+visible = false
+
+[node name="ZoneLabel" type="Label" parent="Control"]
+anchors_preset = 1
+anchor_right = 1.0
+anchor_top = 0.05
+text = "Zone"
+horizontal_alignment = 1
+visible = false
+
+[node name="XPLabel" type="Label" parent="Control"]
+position = Vector2(20, 20)
+text = "XP: 0"
+
+[node name="BadgePanel" type="Panel" parent="Control"]
+position = Vector2(20, 60)
+size = Vector2(220, 180)
+
+[node name="Badges" type="VBoxContainer" parent="Control/BadgePanel"]
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+custom_constants/separation = 6
+
+[node name="Settings" type="VBoxContainer" parent="Control"]
+anchor_left = 1.0
+anchor_right = 1.0
+anchor_top = 0.0
+anchor_bottom = 0.0
+offset_left = -160
+offset_top = 20
+custom_constants/separation = 8
+
+[node name="MuteButton" type="Button" parent="Control/Settings"]
+text = "Mute"
+
+[node name="Panels" type="Control" parent="Control"]
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+
+[node name="HotspotPanel" parent="Control/Panels" instance=ExtResource("2")] 
+
+[node name="MiniGamePanel" parent="Control/Panels" instance=ExtResource("3")] 
+
+[node name="QuizPanel" parent="Control/Panels" instance=ExtResource("4")] 
+
+[node name="DashboardPanel" parent="Control/Panels" instance=ExtResource("5")] 
+

--- a/PalmQuest/scenes/ui/MiniGamePanel.tscn
+++ b/PalmQuest/scenes/ui/MiniGamePanel.tscn
@@ -1,0 +1,45 @@
+[gd_scene load_steps=3 format=3]
+
+[ext_resource type="Script" path="res://scripts/ui/minigame_panel.gd" id="1"]
+
+[node name="MiniGamePanel" type="Control"]
+anchors_preset = 8
+anchor_bottom = 1.0
+anchor_right = 1.0
+visible = false
+script = ExtResource("1")
+
+[node name="MarginContainer" type="MarginContainer" parent="."]
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+custom_constants/margin_left = 32
+custom_constants/margin_right = 32
+custom_constants/margin_top = 32
+custom_constants/margin_bottom = 32
+
+[node name="VBoxContainer" type="VBoxContainer" parent="MarginContainer"]
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+
+[node name="Header" type="HBoxContainer" parent="MarginContainer/VBoxContainer"]
+custom_minimum_size = Vector2(0, 42)
+
+[node name="Title" type="Label" parent="MarginContainer/VBoxContainer/Header"]
+size_flags_horizontal = 3
+text = "Mini-Game"
+uppercase = true
+
+[node name="Timer" type="Label" parent="MarginContainer/VBoxContainer/Header"]
+size_flags_horizontal = 1
+horizontal_alignment = 2
+text = "Time: 45"
+
+[node name="CloseButton" type="Button" parent="MarginContainer/VBoxContainer/Header"]
+text = "End"
+
+[node name="GameContainer" type="Control" parent="MarginContainer/VBoxContainer"]
+size_flags_vertical = 3
+custom_minimum_size = Vector2(0, 300)
+

--- a/PalmQuest/scenes/ui/QuizPanel.tscn
+++ b/PalmQuest/scenes/ui/QuizPanel.tscn
@@ -1,0 +1,63 @@
+[gd_scene load_steps=3 format=3]
+
+[ext_resource type="Script" path="res://scripts/ui/quiz_panel.gd" id="1"]
+
+[node name="QuizPanel" type="Control"]
+anchors_preset = 8
+anchor_bottom = 1.0
+anchor_right = 1.0
+visible = false
+script = ExtResource("1")
+
+[node name="MarginContainer" type="MarginContainer" parent="."]
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+custom_constants/margin_left = 40
+custom_constants/margin_right = 40
+custom_constants/margin_top = 40
+custom_constants/margin_bottom = 40
+
+[node name="VBoxContainer" type="VBoxContainer" parent="MarginContainer"]
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+
+[node name="Header" type="HBoxContainer" parent="MarginContainer/VBoxContainer"]
+custom_minimum_size = Vector2(0, 42)
+
+[node name="Title" type="Label" parent="MarginContainer/VBoxContainer/Header"]
+size_flags_horizontal = 3
+text = "Zone Quiz"
+uppercase = true
+
+[node name="Progress" type="Label" parent="MarginContainer/VBoxContainer/Header"]
+size_flags_horizontal = 1
+horizontal_alignment = 2
+text = "Question 1/5"
+
+[node name="Body" type="VBoxContainer" parent="MarginContainer/VBoxContainer"]
+size_flags_vertical = 3
+
+[node name="Question" type="RichTextLabel" parent="MarginContainer/VBoxContainer/Body"]
+size_flags_vertical = 1
+text = "Question"
+wrap_mode = 1
+
+[node name="Options" type="VBoxContainer" parent="MarginContainer/VBoxContainer/Body"]
+size_flags_vertical = 3
+custom_constants/separation = 8
+
+[node name="Feedback" type="Label" parent="MarginContainer/VBoxContainer/Body"]
+text = ""
+
+[node name="Footer" type="HBoxContainer" parent="MarginContainer/VBoxContainer"]
+alignment = 1
+
+[node name="NextButton" type="Button" parent="MarginContainer/VBoxContainer/Footer"]
+text = "Next"
+disabled = true
+
+[node name="CloseButton" type="Button" parent="MarginContainer/VBoxContainer/Footer"]
+text = "Close"
+

--- a/PalmQuest/scripts/hotspot.gd
+++ b/PalmQuest/scripts/hotspot.gd
@@ -1,0 +1,55 @@
+extends Area3D
+
+class_name Hotspot
+
+signal hotspot_selected(data: Dictionary)
+
+@export var hotspot_id := ""
+@export var zone := ""
+
+var data := {}
+var _player_in_range := false
+var _glow_material: StandardMaterial3D
+
+func _ready() -> void:
+    connect("body_entered", Callable(self, "_on_body_entered"))
+    connect("body_exited", Callable(self, "_on_body_exited"))
+    _glow_material = StandardMaterial3D.new()
+    _glow_material.albedo_color = Color(1.0, 0.9, 0.4, 0.6)
+    _glow_material.emission_enabled = true
+    _glow_material.emission = Color(1.0, 0.8, 0.2)
+    _glow_material.emission_energy = 2.0
+    if has_node("GlowMesh"):
+        var mesh_instance := get_node("GlowMesh") as MeshInstance3D
+        mesh_instance.material_override = _glow_material
+
+func set_data(new_data: Dictionary) -> void:
+    data = new_data
+    hotspot_id = data.get("id", hotspot_id)
+    zone = data.get("zone", zone)
+    if has_node("Billboard/Label3D"):
+        get_node("Billboard/Label3D").text = data.get("title", "Hotspot")
+
+func _process(delta: float) -> void:
+    if has_node("Billboard"):
+        get_node("Billboard").rotate_y(delta * 0.2)
+    if _glow_material:
+        var t := sin(Time.get_ticks_msec() / 250.0)
+        _glow_material.emission_energy = 1.4 + t * 0.6
+
+func focus_changed(is_focused: bool) -> void:
+    _player_in_range = is_focused
+    if has_node("Billboard/Prompt"):
+        get_node("Billboard/Prompt").visible = is_focused
+
+func trigger_interaction() -> void:
+    emit_signal("hotspot_selected", data)
+
+func _on_body_entered(body: Node) -> void:
+    if body.has_method("register_hotspot"):
+        body.register_hotspot(self)
+
+func _on_body_exited(body: Node) -> void:
+    if body.has_method("unregister_hotspot"):
+        body.unregister_hotspot(self)
+    focus_changed(false)

--- a/PalmQuest/scripts/hotspot_manager.gd
+++ b/PalmQuest/scripts/hotspot_manager.gd
@@ -1,0 +1,29 @@
+extends Node3D
+
+signal hotspot_selected(data: Dictionary)
+
+@export var hotspot_scene: PackedScene
+
+var hotspots := {}
+
+func _ready() -> void:
+    _spawn_hotspots()
+
+func _spawn_hotspots() -> void:
+    var entries := DataService.get_hotspots()
+    if entries.is_empty():
+        push_warning("HotspotManager: no hotspot data found")
+        return
+    for entry in entries:
+        if hotspot_scene:
+            var instance := hotspot_scene.instantiate()
+            add_child(instance)
+            var pos := entry.get("position", [0, 0, 0])
+            if pos is Array and pos.size() >= 3:
+                instance.global_transform.origin = Vector3(pos[0], pos[1], pos[2])
+            instance.set_data(entry)
+            instance.connect("hotspot_selected", Callable(self, "_on_hotspot_selected"))
+            hotspots[entry.get("id", "hotspot")] = instance
+
+func _on_hotspot_selected(data: Dictionary) -> void:
+    emit_signal("hotspot_selected", data)

--- a/PalmQuest/scripts/main.gd
+++ b/PalmQuest/scripts/main.gd
@@ -1,0 +1,9 @@
+extends Node
+
+@onready var training_plot := $TrainingPlot
+@onready var hud := $MainHUD
+
+func _ready() -> void:
+    var player := training_plot.get_node("Player")
+    var hotspot_manager := training_plot.get_node("HotspotManager")
+    hud.setup(player, hotspot_manager)

--- a/PalmQuest/scripts/mini_games/fertilizer_game.gd
+++ b/PalmQuest/scripts/mini_games/fertilizer_game.gd
@@ -1,0 +1,85 @@
+extends Control
+
+signal score_updated(score: int)
+signal game_finished(result: Dictionary)
+
+@onready var total_label: Label = $Panel/Info/TotalLabel
+@onready var feedback_label: Label = $Panel/Info/Feedback
+@onready var bag_container: HBoxContainer = $Panel/Bags
+@onready var selection_list: VBoxContainer = $Panel/Selections/List
+@onready var reset_button: Button = $Panel/Selections/Buttons/ResetButton
+@onready var undo_button: Button = $Panel/Selections/Buttons/UndoButton
+
+var _config := {}
+var _target := 0.0
+var _tolerance := 0.0
+var _total := 0.0
+var _score := 0
+var _bags := []
+
+func _ready() -> void:
+    reset_button.connect("pressed", Callable(self, "_on_reset"))
+    undo_button.connect("pressed", Callable(self, "_on_undo"))
+
+func setup(config: Dictionary) -> void:
+    _config = config
+    _target = float(config.get("target_kg_per_ha", 160))
+    _tolerance = float(config.get("tolerance", 8))
+    _total = 0.0
+    _score = 0
+    _bags.clear()
+    for child in bag_container.get_children():
+        child.queue_free()
+    var bag_sizes := config.get("bag_sizes", [10, 15, 20, 25])
+    for size in bag_sizes:
+        var button := Button.new()
+        button.text = "%sg" % str(size)
+        button.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+        button.connect("pressed", Callable(self, "_on_bag_selected").bind(float(size)))
+        bag_container.add_child(button)
+    _clear_selection()
+    _update_labels()
+
+func _on_bag_selected(weight: float) -> void:
+    _bags.append(weight)
+    _total += weight
+    var entry := Label.new()
+    entry.text = "+ %.1f kg" % weight
+    selection_list.add_child(entry)
+    _update_labels()
+
+func _on_reset() -> void:
+    _bags.clear()
+    _total = 0.0
+    _clear_selection()
+    _update_labels()
+
+func _on_undo() -> void:
+    if _bags.is_empty():
+        return
+    var removed := _bags.pop_back()
+    _total -= removed
+    if selection_list.get_child_count() > 0:
+        selection_list.get_child(selection_list.get_child_count() - 1).queue_free()
+    _update_labels()
+
+func _clear_selection() -> void:
+    for child in selection_list.get_children():
+        child.queue_free()
+
+func _update_labels() -> void:
+    total_label.text = "Total: %.1f kg/ha (target %.1f ± %.1f)" % [_total, _target, _tolerance]
+    var diff := abs(_total - _target)
+    if diff <= _tolerance:
+        feedback_label.text = "Within target zone!"
+        _score = int(max(0.0, 100.0 - diff))
+    else:
+        feedback_label.text = "Adjust mix to reach target."
+        _score = int(max(0.0, 100.0 - diff * 0.8))
+    emit_signal("score_updated", _score)
+
+func get_total() -> float:
+    return _total
+
+func get_score() -> int:
+    return _score

--- a/PalmQuest/scripts/mini_games/harvest_game.gd
+++ b/PalmQuest/scripts/mini_games/harvest_game.gd
@@ -1,0 +1,91 @@
+extends Control
+
+signal score_updated(score: int)
+signal game_finished(result: Dictionary)
+
+@onready var grid: GridContainer = $Panel/BunchContainer
+@onready var info_label: Label = $Panel/Info
+
+var _config := {}
+var _bunch_data := []
+var _selections := {}
+var _target_loose := 2
+var _score := 0
+
+func _ready() -> void:
+    set_process(false)
+
+func setup(config: Dictionary) -> void:
+    _config = config
+    _target_loose = int(config.get("loose_fruit_threshold", 2))
+    _bunch_data.clear()
+    _selections.clear()
+    _score = 0
+    for child in grid.get_children():
+        child.queue_free()
+    var count := int(config.get("max_bunches", 12))
+    for i in range(count):
+        var data := _generate_bunch_data()
+        _bunch_data.append(data)
+        var button := Button.new()
+        button.toggle_mode = true
+        button.text = _format_bunch_text(data)
+        button.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+        button.size_flags_vertical = Control.SIZE_EXPAND_FILL
+        button.modulate = data.get("color", Color.WHITE)
+        button.connect("toggled", Callable(self, "_on_bunch_toggled").bind(i))
+        grid.add_child(button)
+    info_label.text = "Select bunches with warm orange fruit and %d loose fruitlets." % _target_loose
+    emit_signal("score_updated", _score)
+
+func _generate_bunch_data() -> Dictionary:
+    var loose := randi_range(0, 4)
+    var stage := "ripe"
+    if loose < _target_loose:
+        stage = "unripe"
+    elif loose > _target_loose:
+        stage = "overripe"
+    var color := stage == "ripe" ? Color(0.85, 0.4, 0.1) : stage == "overripe" ? Color(0.5, 0.2, 0.05) : Color(0.3, 0.6, 0.2)
+    return {
+        "loose": loose,
+        "stage": stage,
+        "color": color
+    }
+
+func _format_bunch_text(data: Dictionary) -> String:
+    return "%s\nLoose: %d" % [data.get("stage", "ripe").capitalize(), data.get("loose", 0)]
+
+func _on_bunch_toggled(pressed: bool, index: int) -> void:
+    _selections[index] = pressed
+    _update_score()
+
+func _update_score() -> void:
+    var correct := 0
+    var total_targets := 0
+    for i in range(_bunch_data.size()):
+        var data := _bunch_data[i]
+        var is_target := data.get("stage", "") == "ripe"
+        if is_target:
+            total_targets += 1
+        var selected := _selections.get(i, false)
+        if selected and is_target:
+            correct += 1
+        elif selected and not is_target:
+            correct -= 1
+    var accuracy := 0.0
+    if total_targets > 0:
+        accuracy = max(0.0, float(correct) / float(total_targets))
+    _score = int(clamp(accuracy * 100.0, 0.0, 100.0))
+    emit_signal("score_updated", _score)
+
+func get_accuracy() -> float:
+    if _bunch_data.is_empty():
+        return 0.0
+    return clamp(float(_score) / 100.0, 0.0, 1.0)
+
+func get_score() -> int:
+    return _score
+
+func update_time(time_left: float) -> void:
+    if time_left <= 10:
+        info_label.text = "Final checks! Confirm only bunches with %d loose fruits." % _target_loose

--- a/PalmQuest/scripts/mini_games/pollination_game.gd
+++ b/PalmQuest/scripts/mini_games/pollination_game.gd
@@ -1,0 +1,98 @@
+extends Control
+
+signal score_updated(score: int)
+signal game_finished(result: Dictionary)
+
+@onready var net: ColorRect = $Panel/Net
+@onready var beetle_container: Node = $Panel/Beetles
+@onready var info_label: Label = $Panel/Info
+
+var _config := {}
+var _score := 0
+var _spawn_timer := 0.0
+var _spawn_interval := 1.0
+var _time_total := 45.0
+var _time_left := 45.0
+
+func _ready() -> void:
+    set_process(false)
+
+func setup(config: Dictionary) -> void:
+    _config = config
+    _score = 0
+    _spawn_interval = float(config.get("spawn_interval", 1.0))
+    _time_total = float(config.get("time_limit", 45.0))
+    _time_left = _time_total
+    info_label.text = "Capture beetles carrying pollen. Use WASD to move the net."
+    net.position = Vector2(50, rect_size().y / 2)
+    _clear_beetles()
+    emit_signal("score_updated", _score)
+    set_process(true)
+
+func rect_size() -> Vector2:
+    return $Panel.size
+
+func _process(delta: float) -> void:
+    _spawn_timer += delta
+    if _spawn_timer >= _spawn_interval:
+        _spawn_timer = 0.0
+        _spawn_beetle()
+    _handle_input(delta)
+    _update_beetles(delta)
+
+func update_time(time_left: float) -> void:
+    _time_left = max(time_left, 0.0)
+    var optimal_start := float(_config.get("optimal_window_start", 0))
+    var optimal_end := float(_config.get("optimal_window_end", 999))
+    var elapsed := _time_total - _time_left
+    if elapsed >= optimal_start and elapsed <= optimal_end:
+        info_label.text = "Perfect timing! Beetles swarm receptive blooms."
+        $Panel.color = Color(0.2, 0.5, 0.3, 0.15)
+    else:
+        info_label.text = "Wait for optimal dawn humidity to peak."
+        $Panel.color = Color(0.4, 0.3, 0.1, 0.15)
+
+func get_score() -> int:
+    return _score
+
+func _handle_input(delta: float) -> void:
+    var move := Vector2.ZERO
+    if Input.is_action_pressed("move_left"):
+        move.x -= 1
+    if Input.is_action_pressed("move_right"):
+        move.x += 1
+    if Input.is_action_pressed("move_forward"):
+        move.y -= 1
+    if Input.is_action_pressed("move_back"):
+        move.y += 1
+    if move != Vector2.ZERO:
+        move = move.normalized() * 220 * delta
+        net.position += move
+        var panel_rect := Rect2(Vector2.ZERO, rect_size())
+        net.position = net.position.clamp(panel_rect.position, panel_rect.end - net.size)
+
+func _spawn_beetle() -> void:
+    var beetle := ColorRect.new()
+    beetle.color = Color(1.0, 0.8, 0.2, 0.9)
+    beetle.size = Vector2(24, 24)
+    var x := randf_range(0, rect_size().x - beetle.size.x)
+    beetle.position = Vector2(x, -beetle.size.y)
+    beetle.set_meta("velocity", Vector2(randf_range(-20, 20), randf_range(110, 170)))
+    beetle_container.add_child(beetle)
+
+func _update_beetles(delta: float) -> void:
+    var net_rect := Rect2(net.position, net.size)
+    for beetle in beetle_container.get_children():
+        var vel: Vector2 = beetle.get_meta("velocity")
+        beetle.position += vel * delta
+        if beetle.position.y > rect_size().y:
+            beetle.queue_free()
+            continue
+        if net_rect.has_point(beetle.position + beetle.size * 0.5):
+            _score += 1
+            emit_signal("score_updated", _score)
+            beetle.queue_free()
+
+func _clear_beetles() -> void:
+    for beetle in beetle_container.get_children():
+        beetle.queue_free()

--- a/PalmQuest/scripts/palm_rows.gd
+++ b/PalmQuest/scripts/palm_rows.gd
@@ -1,0 +1,26 @@
+extends MultiMeshInstance3D
+
+@export var rows := 5
+@export var columns := 8
+@export var spacing := Vector3(6, 0, 6)
+
+func _ready() -> void:
+    if multimesh == null:
+        multimesh = MultiMesh.new()
+    if multimesh.mesh == null:
+        var mesh := CylinderMesh.new()
+        mesh.radius = 0.35
+        mesh.height = 6.0
+        var material := StandardMaterial3D.new()
+        material.albedo_color = Color(0.4, 0.28, 0.18)
+        mesh.material = material
+        multimesh.mesh = mesh
+    multimesh.instance_count = rows * columns
+    var index := 0
+    for r in range(rows):
+        for c in range(columns):
+            var x := (c - columns / 2.0) * spacing.x
+            var z := (r - rows / 2.0) * spacing.z
+            var transform := Transform3D(Basis(), Vector3(x, 3.0, z))
+            multimesh.set_instance_transform(index, transform)
+            index += 1

--- a/PalmQuest/scripts/player.gd
+++ b/PalmQuest/scripts/player.gd
@@ -1,0 +1,94 @@
+extends CharacterBody3D
+
+signal hotspot_focused(hotspot)
+signal hotspot_interacted(hotspot)
+
+@export var speed := 4.5
+@export var sprint_multiplier := 1.6
+@export var gravity := 12.0
+@export var mouse_sensitivity := 0.15
+
+var _yaw := 0.0
+var _pitch := 0.0
+var _camera: Camera3D
+var _hotspots: Array = []
+
+func _ready() -> void:
+    Input.set_mouse_mode(Input.MOUSE_MODE_CAPTURED)
+    _camera = $Camera3D
+
+func _unhandled_input(event: InputEvent) -> void:
+    if event is InputEventMouseMotion and Input.get_mouse_mode() == Input.MOUSE_MODE_CAPTURED:
+        _yaw -= event.relative.x * mouse_sensitivity * 0.01
+        _pitch -= event.relative.y * mouse_sensitivity * 0.01
+        _pitch = clamp(_pitch, deg_to_rad(-80), deg_to_rad(75))
+        rotation.y = _yaw
+        _camera.rotation.x = _pitch
+    elif event is InputEventKey and event.pressed and event.keycode == Key.ESCAPE:
+        Input.set_mouse_mode(Input.MOUSE_MODE_VISIBLE)
+
+func _physics_process(delta: float) -> void:
+    var input_dir := Vector3.ZERO
+    var forward := -transform.basis.z
+    var right := transform.basis.x
+
+    if Input.is_action_pressed("move_forward"):
+        input_dir += forward
+    if Input.is_action_pressed("move_back"):
+        input_dir -= forward
+    if Input.is_action_pressed("move_left"):
+        input_dir -= right
+    if Input.is_action_pressed("move_right"):
+        input_dir += right
+
+    input_dir = input_dir.normalized()
+    var target_speed := speed
+    if Input.is_action_pressed("sprint"):
+        target_speed *= sprint_multiplier
+
+    var horizontal_velocity := input_dir * target_speed
+    velocity.x = horizontal_velocity.x
+    velocity.z = horizontal_velocity.z
+
+    if not is_on_floor():
+        velocity.y -= gravity * delta
+    else:
+        velocity.y = 0.0
+
+    move_and_slide()
+
+    if Input.is_action_just_pressed("interact"):
+        _attempt_interact()
+
+    _update_hotspot_focus()
+
+func _attempt_interact() -> void:
+    var hotspot = _get_primary_hotspot()
+    if hotspot:
+        emit_signal("hotspot_interacted", hotspot)
+
+func register_hotspot(hotspot: Node) -> void:
+    if hotspot not in _hotspots:
+        _hotspots.append(hotspot)
+        _update_hotspot_focus()
+
+func unregister_hotspot(hotspot: Node) -> void:
+    if hotspot in _hotspots:
+        _hotspots.erase(hotspot)
+        _update_hotspot_focus()
+
+func _update_hotspot_focus() -> void:
+    var hotspot = _get_primary_hotspot()
+    emit_signal("hotspot_focused", hotspot)
+
+func _get_primary_hotspot():
+    var closest
+    var closest_dist := INF
+    for hotspot in _hotspots:
+        if not is_instance_valid(hotspot):
+            continue
+        var dist := global_transform.origin.distance_to(hotspot.global_transform.origin)
+        if dist < closest_dist:
+            closest_dist = dist
+            closest = hotspot
+    return closest

--- a/PalmQuest/scripts/singletons/audio_service.gd
+++ b/PalmQuest/scripts/singletons/audio_service.gd
@@ -1,0 +1,61 @@
+extends Node
+
+## Central audio controller that plays ambience and UI sounds and respects mute settings.
+class_name AudioService
+
+@export var ambient_stream: AudioStream
+@export var ui_click_stream: AudioStream
+
+var _ambient_player: AudioStreamPlayer
+var _ui_player: AudioStreamPlayer
+
+func _ready() -> void:
+    _ambient_player = AudioStreamPlayer.new()
+    _ambient_player.bus = "Master"
+    _ambient_player.autoplay = false
+    add_child(_ambient_player)
+
+    _ui_player = AudioStreamPlayer.new()
+    _ui_player.bus = "Master"
+    add_child(_ui_player)
+
+    if ambient_stream:
+        _ambient_player.stream = ambient_stream
+        _ambient_player.loop = true
+        if not GameState.is_muted():
+            _ambient_player.play()
+
+    GameState.connect("badge_unlocked", Callable(self, "_on_badge_unlocked"))
+
+func set_muted(muted: bool) -> void:
+    GameState.set_muted(muted)
+    _update_mute_state()
+
+func toggle_mute() -> bool:
+    var new_state := not GameState.is_muted()
+    set_muted(new_state)
+    return new_state
+
+func _update_mute_state() -> void:
+    var muted := GameState.is_muted()
+    if muted:
+        if _ambient_player.playing:
+            _ambient_player.stop()
+    else:
+        if ambient_stream and not _ambient_player.playing:
+            _ambient_player.play()
+    _ambient_player.volume_db = -80 if muted else 0
+    _ui_player.volume_db = -80 if muted else -3
+
+func play_ui_click() -> void:
+    if not ui_click_stream or GameState.is_muted():
+        return
+    _ui_player.stream = ui_click_stream
+    _ui_player.play()
+
+func _on_badge_unlocked(_zone: String) -> void:
+    if not GameState.is_muted():
+        _ui_player.pitch_scale = 1.2
+        _ui_player.stream = ui_click_stream
+        _ui_player.play()
+        _ui_player.pitch_scale = 1.0

--- a/PalmQuest/scripts/singletons/data_service.gd
+++ b/PalmQuest/scripts/singletons/data_service.gd
@@ -1,0 +1,57 @@
+extends Node
+
+## Provides access to static game data stored in JSON files under `res://data`.
+class_name DataService
+
+var _cache := {}
+
+func _ready() -> void:
+    _cache.clear()
+
+func _load_json(path: String) -> Dictionary:
+    if _cache.has(path):
+        return _cache[path]
+    var full_path := "res://data/%s" % path
+    if not FileAccess.file_exists(full_path):
+        push_error("DataService: missing file %s" % full_path)
+        return {}
+    var content := FileAccess.get_file_as_string(full_path)
+    var parser := JSON.new()
+    var error := parser.parse(content)
+    if error != OK:
+        push_error("DataService: failed to parse %s: %s" % [full_path, parser.get_error_message()])
+        return {}
+    var data := parser.get_data()
+    if typeof(data) != TYPE_DICTIONARY:
+        push_warning("DataService: root of %s is not a dictionary" % full_path)
+        data = {}
+    _cache[path] = data
+    return data
+
+func get_hotspots() -> Array:
+    var data := _load_json("hotspots.json")
+    return data.get("hotspots", [])
+
+func get_quiz(zone: String) -> Dictionary:
+    var quizzes := _load_json("quizzes.json")
+    var zones := quizzes.get("zones", {})
+    return zones.get(zone, {})
+
+func get_all_quizzes() -> Dictionary:
+    var quizzes := _load_json("quizzes.json")
+    return quizzes.get("zones", {})
+
+func get_minigame_config(id: String) -> Dictionary:
+    var games := _load_json("minigames.json")
+    var mini := games.get("mini_games", {})
+    return mini.get(id, {})
+
+func get_glossary() -> Dictionary:
+    var glossary := _load_json("glossary.json")
+    return glossary.get("terms", {})
+
+func get_production_demo() -> Dictionary:
+    return _load_json("production_demo.json")
+
+func reload() -> void:
+    _cache.clear()

--- a/PalmQuest/scripts/singletons/game_state.gd
+++ b/PalmQuest/scripts/singletons/game_state.gd
@@ -1,0 +1,104 @@
+extends Node
+
+## Tracks persistent player progress such as badges, quiz results, and settings.
+class_name GameState
+
+signal badge_unlocked(zone: String)
+signal quiz_completed(zone: String, score: int, passed: bool)
+signal minigame_score_updated(game_id: String, score: int)
+
+const SAVE_PATH := "user://palmquest.cfg"
+
+var badges := {}
+var quiz_results := {}
+var minigame_scores := {}
+var xp := 0
+var muted := false
+
+func _ready() -> void:
+    load_state()
+
+func reset() -> void:
+    badges.clear()
+    quiz_results.clear()
+    minigame_scores.clear()
+    xp = 0
+    muted = false
+    save_state()
+
+func load_state() -> void:
+    var cfg := ConfigFile.new()
+    var err := cfg.load(SAVE_PATH)
+    if err != OK:
+        return
+    badges = cfg.get_value("progress", "badges", {})
+    quiz_results = cfg.get_value("progress", "quiz_results", {})
+    minigame_scores = cfg.get_value("progress", "minigame_scores", {})
+    xp = cfg.get_value("progress", "xp", 0)
+    muted = cfg.get_value("settings", "muted", false)
+
+func save_state() -> void:
+    var cfg := ConfigFile.new()
+    cfg.set_value("progress", "badges", badges)
+    cfg.set_value("progress", "quiz_results", quiz_results)
+    cfg.set_value("progress", "minigame_scores", minigame_scores)
+    cfg.set_value("progress", "xp", xp)
+    cfg.set_value("settings", "muted", muted)
+    var err := cfg.save(SAVE_PATH)
+    if err != OK:
+        push_error("GameState: failed to save %s" % SAVE_PATH)
+
+func unlock_badge(zone: String, amount_xp: int = 50) -> void:
+    if badges.get(zone, false):
+        return
+    badges[zone] = true
+    xp += amount_xp
+    save_state()
+    emit_signal("badge_unlocked", zone)
+
+func has_badge(zone: String) -> bool:
+    return badges.get(zone, false)
+
+func record_quiz(zone: String, score: int, passed: bool) -> void:
+    quiz_results[zone] = {
+        "score": score,
+        "passed": passed,
+        "timestamp": Time.get_unix_time_from_system()
+    }
+    if passed:
+        unlock_badge(zone, 75)
+    else:
+        save_state()
+    emit_signal("quiz_completed", zone, score, passed)
+
+func get_quiz_result(zone: String) -> Dictionary:
+    return quiz_results.get(zone, {})
+
+func record_minigame_score(game_id: String, score: int) -> void:
+    var best := minigame_scores.get(game_id, 0)
+    if score > best:
+        minigame_scores[game_id] = score
+        xp += int(score / 5)
+        save_state()
+    else:
+        save_state()
+    emit_signal("minigame_score_updated", game_id, score)
+
+func get_minigame_score(game_id: String) -> int:
+    return minigame_scores.get(game_id, 0)
+
+func total_badges() -> int:
+    return badges.size()
+
+func all_badges_unlocked(required_zones: Array) -> bool:
+    for zone in required_zones:
+        if not badges.get(zone, false):
+            return false
+    return true
+
+func set_muted(value: bool) -> void:
+    muted = value
+    save_state()
+
+func is_muted() -> bool:
+    return muted

--- a/PalmQuest/scripts/ui/dashboard_panel.gd
+++ b/PalmQuest/scripts/ui/dashboard_panel.gd
@@ -1,0 +1,40 @@
+extends Control
+
+signal panel_closed
+
+@onready var badge_label: Label = $MarginContainer/VBoxContainer/Header/BadgeSummary
+@onready var summary_label: RichTextLabel = $MarginContainer/VBoxContainer/Body/Summary
+@onready var chart: Control = $MarginContainer/VBoxContainer/Body/ChartContainer/ProductionChart
+@onready var close_button: Button = $MarginContainer/VBoxContainer/Header/CloseButton
+
+var _data := {}
+
+func _ready() -> void:
+    hide()
+    close_button.connect("pressed", Callable(self, "_on_close_pressed"))
+
+func show_dashboard() -> void:
+    _data = DataService.get_production_demo()
+    if chart.has_method("set_data"):
+        chart.set_data(_data)
+    var total_badges := GameState.total_badges()
+    badge_label.text = "Badges earned: %d" % total_badges
+    var glossary := DataService.get_glossary()
+    summary_label.text = "[center][b]Monthly Insights[/b][/center]\n"
+    summary_label.text += "Average OER: %.1f%%" % _average(_data.get("monthly", []), "oer_percent") + "\n"
+    summary_label.text += "Average FFB: %.0f tonnes" % _average(_data.get("monthly", []), "ffb_tonnes") + "\n"
+    summary_label.text += "Terms: [b]FFB[/b] - %s\n" % glossary.get("FFB", "Fresh Fruit Bunch")
+    summary_label.text += "[b]OER[/b] - %s" % glossary.get("OER", "Oil Extraction Rate")
+    show()
+
+func _average(entries: Array, key: String) -> float:
+    if entries.is_empty():
+        return 0.0
+    var total := 0.0
+    for entry in entries:
+        total += float(entry.get(key, 0))
+    return total / entries.size()
+
+func _on_close_pressed() -> void:
+    hide()
+    emit_signal("panel_closed")

--- a/PalmQuest/scripts/ui/hotspot_panel.gd
+++ b/PalmQuest/scripts/ui/hotspot_panel.gd
@@ -1,0 +1,48 @@
+extends Control
+
+signal request_minigame(id: String)
+signal request_quiz(zone: String)
+signal panel_closed
+
+@onready var title_label: Label = $MarginContainer/VBoxContainer/Header/Title
+@onready var icon_texture: TextureRect = $MarginContainer/VBoxContainer/Header/Icon
+@onready var body_text: RichTextLabel = $MarginContainer/VBoxContainer/Body/Text
+@onready var mini_game_button: Button = $MarginContainer/VBoxContainer/Actions/MiniGameButton
+@onready var quiz_button: Button = $MarginContainer/VBoxContainer/Actions/QuizButton
+
+var current_hotspot := {}
+
+func _ready() -> void:
+    hide()
+    mini_game_button.connect("pressed", Callable(self, "_on_mini_game_pressed"))
+    quiz_button.connect("pressed", Callable(self, "_on_quiz_pressed"))
+    $MarginContainer/VBoxContainer/Actions/CloseButton.connect("pressed", Callable(self, "_on_close_pressed"))
+
+func show_hotspot(data: Dictionary) -> void:
+    current_hotspot = data
+    title_label.text = data.get("title", "Hotspot")
+    body_text.text = data.get("text", "")
+    var icon_path := data.get("icon", "")
+    if icon_path != "" and ResourceLoader.exists(icon_path):
+        icon_texture.texture = ResourceLoader.load(icon_path)
+    else:
+        icon_texture.texture = null
+    var mini_game := data.get("mini_game_id")
+    mini_game_button.visible = mini_game != null and mini_game != ""
+    mini_game_button.disabled = not mini_game_button.visible
+    var zone := data.get("zone", "")
+    quiz_button.visible = zone != ""
+    show()
+
+func _on_mini_game_pressed() -> void:
+    if current_hotspot.has("mini_game_id") and current_hotspot["mini_game_id"]:
+        emit_signal("request_minigame", str(current_hotspot["mini_game_id"]))
+
+func _on_quiz_pressed() -> void:
+    var zone := current_hotspot.get("zone", "")
+    if zone != "":
+        emit_signal("request_quiz", zone)
+
+func _on_close_pressed() -> void:
+    hide()
+    emit_signal("panel_closed")

--- a/PalmQuest/scripts/ui/main_hud.gd
+++ b/PalmQuest/scripts/ui/main_hud.gd
@@ -1,0 +1,128 @@
+extends CanvasLayer
+
+@onready var prompt_label: Label = $Control/Prompt
+@onready var zone_label: Label = $Control/ZoneLabel
+@onready var xp_label: Label = $Control/XPLabel
+@onready var badge_container: VBoxContainer = $Control/BadgePanel/Badges
+@onready var hotspot_panel: Control = $Control/Panels/HotspotPanel
+@onready var mini_game_panel: Control = $Control/Panels/MiniGamePanel
+@onready var quiz_panel: Control = $Control/Panels/QuizPanel
+@onready var dashboard_panel: Control = $Control/Panels/DashboardPanel
+@onready var mute_button: Button = $Control/Settings/MuteButton
+
+var _player
+var _current_hotspot
+
+func _ready() -> void:
+    prompt_label.visible = false
+    zone_label.visible = false
+    xp_label.text = "XP: %d" % GameState.xp
+    _refresh_badges()
+    GameState.connect("badge_unlocked", Callable(self, "_on_badge_unlocked"))
+    GameState.connect("minigame_score_updated", Callable(self, "_on_minigame_score"))
+    if hotspot_panel.has_signal("request_minigame"):
+        hotspot_panel.connect("request_minigame", Callable(self, "_on_request_minigame"))
+    if hotspot_panel.has_signal("request_quiz"):
+        hotspot_panel.connect("request_quiz", Callable(self, "_on_request_quiz"))
+    if mini_game_panel.has_signal("minigame_completed"):
+        mini_game_panel.connect("minigame_completed", Callable(self, "_on_minigame_completed"))
+    if quiz_panel.has_signal("quiz_completed"):
+        quiz_panel.connect("quiz_completed", Callable(self, "_on_quiz_completed"))
+    mute_button.connect("pressed", Callable(self, "_on_mute_button_pressed"))
+    _update_mute_button()
+
+func setup(player: Node, hotspot_manager: Node) -> void:
+    _player = player
+    if _player:
+        _player.connect("hotspot_focused", Callable(self, "_on_hotspot_focused"))
+        _player.connect("hotspot_interacted", Callable(self, "_on_hotspot_interacted"))
+    if hotspot_manager and hotspot_manager.has_signal("hotspot_selected"):
+        hotspot_manager.connect("hotspot_selected", Callable(self, "_on_hotspot_selected"))
+
+func _process(delta: float) -> void:
+    if Input.is_action_just_pressed("open_dashboard"):
+        _toggle_dashboard()
+    if Input.is_action_just_pressed("pause_menu"):
+        if Input.get_mouse_mode() == Input.MOUSE_MODE_CAPTURED:
+            Input.set_mouse_mode(Input.MOUSE_MODE_VISIBLE)
+        else:
+            Input.set_mouse_mode(Input.MOUSE_MODE_CAPTURED)
+
+func _on_hotspot_focused(hotspot) -> void:
+    if _current_hotspot and _current_hotspot != hotspot and _current_hotspot.has_method("focus_changed"):
+        _current_hotspot.focus_changed(false)
+    _current_hotspot = hotspot
+    if hotspot:
+        if hotspot.has_method("focus_changed"):
+            hotspot.focus_changed(true)
+        var data := hotspot.get("data")
+        prompt_label.text = "Press E to inspect %s" % data.get("title", "Hotspot")
+        prompt_label.visible = true
+        zone_label.text = data.get("zone", "")
+        zone_label.visible = zone_label.text != ""
+    else:
+        prompt_label.visible = false
+        zone_label.visible = false
+
+func _on_hotspot_interacted(hotspot) -> void:
+    if hotspot and hotspot.has_method("trigger_interaction"):
+        hotspot.trigger_interaction()
+
+func _on_hotspot_selected(data: Dictionary) -> void:
+    hotspot_panel.show_hotspot(data)
+
+func _on_request_minigame(id: String) -> void:
+    mini_game_panel.show_minigame(id)
+
+func _on_request_quiz(zone: String) -> void:
+    quiz_panel.show_quiz(zone)
+
+func _on_minigame_completed(game_id: String, score: int, success: bool) -> void:
+    GameState.record_minigame_score(game_id, score)
+    xp_label.text = "XP: %d" % GameState.xp
+    var message := "%s score: %d" % [game_id, score]
+    if success:
+        message += " — within target!"
+    prompt_label.text = message
+    prompt_label.visible = true
+
+func _on_quiz_completed(zone: String, score: int, passed: bool) -> void:
+    GameState.record_quiz(zone, score, passed)
+    xp_label.text = "XP: %d" % GameState.xp
+    _refresh_badges()
+    prompt_label.text = "%s quiz %s (%d correct)" % [zone.capitalize(), passed ? "passed" : "retry", score]
+    prompt_label.visible = true
+
+func _on_badge_unlocked(_zone: String) -> void:
+    xp_label.text = "XP: %d" % GameState.xp
+    _refresh_badges()
+
+func _on_minigame_score(_game: String, _score: int) -> void:
+    xp_label.text = "XP: %d" % GameState.xp
+
+func _refresh_badges() -> void:
+    for child in badge_container.get_children():
+        child.queue_free()
+    for zone in ["pollination", "fertilization", "timeline", "production"]:
+        var badge := HBoxContainer.new()
+        badge.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+        var label := Label.new()
+        label.text = "%s: %s" % [zone.capitalize(), GameState.has_badge(zone) ? "Unlocked" : "Pending"]
+        badge.add_child(label)
+        badge_container.add_child(badge)
+    if GameState.all_badges_unlocked(["pollination", "fertilization", "timeline", "production"]):
+        prompt_label.text = "Dashboard Hut unlocked! Press P to view production analytics."
+        prompt_label.visible = true
+
+func _toggle_dashboard() -> void:
+    if dashboard_panel.visible:
+        dashboard_panel.hide()
+    else:
+        dashboard_panel.show_dashboard()
+
+func _on_mute_button_pressed() -> void:
+    AudioService.toggle_mute()
+    _update_mute_button()
+
+func _update_mute_button() -> void:
+    mute_button.text = "Unmute" if GameState.is_muted() else "Mute"

--- a/PalmQuest/scripts/ui/minigame_panel.gd
+++ b/PalmQuest/scripts/ui/minigame_panel.gd
@@ -1,0 +1,114 @@
+extends Control
+
+signal minigame_completed(game_id: String, score: int, success: bool)
+signal panel_closed
+
+@onready var title_label: Label = $MarginContainer/VBoxContainer/Header/Title
+@onready var timer_label: Label = $MarginContainer/VBoxContainer/Header/Timer
+@onready var container: Control = $MarginContainer/VBoxContainer/GameContainer
+
+var _game_scenes := {
+    "pollination_catcher": preload("res://scenes/mini_games/PollinationGame.tscn"),
+    "fertilizer_mixer": preload("res://scenes/mini_games/FertilizerGame.tscn"),
+    "harvest_timing": preload("res://scenes/mini_games/HarvestGame.tscn")
+}
+
+var _game_instance: Control
+var _current_game_id := ""
+var _config := {}
+var _time_left := 0.0
+var _ended := false
+
+func _ready() -> void:
+    hide()
+    $MarginContainer/VBoxContainer/Header/CloseButton.connect("pressed", Callable(self, "_on_close_pressed"))
+    set_process(false)
+
+func show_minigame(game_id: String) -> void:
+    if not _game_scenes.has(game_id):
+        push_error("MiniGamePanel: unknown game %s" % game_id)
+        return
+    _clear_game()
+    _current_game_id = game_id
+    _config = DataService.get_minigame_config(game_id)
+    _time_left = float(_config.get("time_limit", 45))
+    _ended = false
+    title_label.text = _config.get("name", "Mini-Game")
+    var packed: PackedScene = _game_scenes[game_id]
+    _game_instance = packed.instantiate()
+    container.add_child(_game_instance)
+    if _game_instance.has_signal("game_finished"):
+        _game_instance.connect("game_finished", Callable(self, "_on_game_finished"))
+    if _game_instance.has_signal("score_updated"):
+        _game_instance.connect("score_updated", Callable(self, "_on_score_updated"))
+    if _game_instance.has_method("setup"):
+        _game_instance.setup(_config)
+    show()
+    set_process(true)
+    _update_timer_label()
+
+func _process(delta: float) -> void:
+    if _ended:
+        return
+    _time_left -= delta
+    if _game_instance and _game_instance.has_method("update_time"):
+        _game_instance.update_time(_time_left)
+    if _time_left <= 0.0:
+        _time_left = 0.0
+        _finalize_game()
+    _update_timer_label()
+
+func _update_timer_label() -> void:
+    timer_label.text = "Time: %02d" % int(clamp(round(_time_left), 0, 999))
+
+func _on_game_finished(result: Dictionary) -> void:
+    if _ended:
+        return
+    var score := int(result.get("score", 0))
+    var success := result.get("success", false)
+    _ended = true
+    _emit_result(score, success)
+
+func _finalize_game() -> void:
+    if _ended:
+        return
+    var score := 0
+    var success := false
+    if _game_instance:
+        if _game_instance.has_method("get_score"):
+            score = int(_game_instance.get_score())
+        if _config.has("target_score"):
+            success = score >= int(_config.get("target_score", 0))
+        elif _config.has("target_accuracy") and _game_instance.has_method("get_accuracy"):
+            success = float(_game_instance.get_accuracy()) >= float(_config.get("target_accuracy", 0.0))
+            score = int(float(_game_instance.get_accuracy()) * 100.0)
+        elif _config.has("target_kg_per_ha") and _game_instance.has_method("get_total"):
+            var total := float(_game_instance.get_total())
+            var diff := abs(total - float(_config.get("target_kg_per_ha", 0)))
+            var tolerance := float(_config.get("tolerance", 0))
+            success = diff <= tolerance
+            score = int(max(0.0, 100.0 - diff))
+    _ended = true
+    _emit_result(score, success)
+
+func _emit_result(score: int, success: bool) -> void:
+    hide()
+    set_process(false)
+    emit_signal("minigame_completed", _current_game_id, score, success)
+    emit_signal("panel_closed")
+    _clear_game()
+
+func _on_score_updated(_score: int) -> void:
+    pass
+
+func _on_close_pressed() -> void:
+    _finalize_game()
+
+func _clear_game() -> void:
+    if _game_instance and is_instance_valid(_game_instance):
+        _game_instance.queue_free()
+    _game_instance = null
+    _current_game_id = ""
+    _config = {}
+    _time_left = 0.0
+    _ended = false

--- a/PalmQuest/scripts/ui/production_chart.gd
+++ b/PalmQuest/scripts/ui/production_chart.gd
@@ -1,0 +1,75 @@
+extends Control
+
+var _months: Array = []
+var _ffb: Array = []
+var _oer: Array = []
+var _prices: Array = []
+var _targets := {}
+
+func set_data(data: Dictionary) -> void:
+    var monthly := data.get("monthly", [])
+    _months.clear()
+    _ffb.clear()
+    _oer.clear()
+    _prices.clear()
+    for entry in monthly:
+        _months.append(entry.get("month", ""))
+        _ffb.append(float(entry.get("ffb_tonnes", 0)))
+        _oer.append(float(entry.get("oer_percent", 0)))
+        _prices.append(float(entry.get("cpo_price_usd", 0)))
+    _targets = data.get("targets", {})
+    update()
+
+func _draw() -> void:
+    if _months.is_empty():
+        return
+    var rect := Rect2(Vector2(30, 20), size - Vector2(60, 60))
+    draw_rect(rect, Color(0, 0, 0, 0), false, Color(0.2, 0.4, 0.3))
+    var max_ffb := 1.0
+    for value in _ffb:
+        max_ffb = max(max_ffb, value)
+    var max_price := 1.0
+    for value in _prices:
+        max_price = max(max_price, value)
+    var min_oer := _oer[0]
+    var max_oer := _oer[0]
+    for value in _oer:
+        min_oer = min(min_oer, value)
+        max_oer = max(max_oer, value)
+    if _targets.has("oer_percent"):
+        min_oer = min(min_oer, float(_targets["oer_percent"]))
+        max_oer = max(max_oer, float(_targets["oer_percent"]))
+    if max_oer == min_oer:
+        max_oer += 1.0
+    var count := _months.size()
+    var step := rect.size.x / max(count, 1)
+    var font := get_theme_default_font()
+    var font_size := 14
+
+    for i in range(count):
+        var bar_height := (_ffb[i] / max_ffb) * rect.size.y * 0.6
+        var bar_rect := Rect2(rect.position + Vector2(i * step + step * 0.15, rect.position.y + rect.size.y * 0.6 - bar_height), Vector2(step * 0.3, bar_height))
+        draw_rect(bar_rect, Color(0.3, 0.7, 0.4, 0.8))
+
+        var price_height := (_prices[i] / max_price) * rect.size.y * 0.3
+        var price_rect := Rect2(rect.position + Vector2(i * step + step * 0.55, rect.position.y + rect.size.y * 0.3 - price_height), Vector2(step * 0.25, price_height))
+        draw_rect(price_rect, Color(0.9, 0.6, 0.4, 0.7))
+
+        var label_pos := Vector2(rect.position.x + i * step + step * 0.1, rect.end.y + 18)
+        draw_string(font, label_pos, _months[i], HORIZONTAL_ALIGNMENT_LEFT, step * 0.8, font_size, Color(0.1, 0.2, 0.1))
+
+    var line_points := PackedVector2Array()
+    for i in range(count):
+        var ratio := (_oer[i] - min_oer) / (max_oer - min_oer)
+        var y := rect.position.y + rect.size.y - ratio * rect.size.y
+        line_points.append(Vector2(rect.position.x + i * step + step * 0.5, y))
+    if line_points.size() > 1:
+        draw_polyline(line_points, Color(0.2, 0.4, 0.8), 2.0)
+
+    if _targets.has("oer_percent"):
+        var ratio_target := (float(_targets["oer_percent"]) - min_oer) / (max_oer - min_oer)
+        var y_target := rect.position.y + rect.size.y - ratio_target * rect.size.y
+        draw_line(Vector2(rect.position.x, y_target), Vector2(rect.end.x, y_target), Color(0.8, 0.2, 0.2), 1.5)
+        draw_string(font, Vector2(rect.end.x - 120, y_target - 6), "OER Target", HORIZONTAL_ALIGNMENT_LEFT, 120, font_size, Color(0.8, 0.2, 0.2))
+
+    draw_string(font, rect.position - Vector2(0, 8), "FFB (green) vs Price (amber) — OER line", HORIZONTAL_ALIGNMENT_LEFT, rect.size.x, font_size, Color(0.15, 0.15, 0.15))

--- a/PalmQuest/scripts/ui/quiz_panel.gd
+++ b/PalmQuest/scripts/ui/quiz_panel.gd
@@ -1,0 +1,102 @@
+extends Control
+
+signal quiz_completed(zone: String, score: int, passed: bool)
+signal panel_closed
+
+@onready var title_label: Label = $MarginContainer/VBoxContainer/Header/Title
+@onready var question_label: RichTextLabel = $MarginContainer/VBoxContainer/Body/Question
+@onready var options_container: VBoxContainer = $MarginContainer/VBoxContainer/Body/Options
+@onready var feedback_label: Label = $MarginContainer/VBoxContainer/Body/Feedback
+@onready var progress_label: Label = $MarginContainer/VBoxContainer/Header/Progress
+@onready var next_button: Button = $MarginContainer/VBoxContainer/Footer/NextButton
+@onready var close_button: Button = $MarginContainer/VBoxContainer/Footer/CloseButton
+
+var _zone := ""
+var _questions: Array = []
+var _current_index := 0
+var _score := 0
+var _pass_score := 4
+var _answered := false
+
+func _ready() -> void:
+    hide()
+    next_button.connect("pressed", Callable(self, "_on_next_pressed"))
+    close_button.connect("pressed", Callable(self, "_on_close_pressed"))
+
+func show_quiz(zone: String) -> void:
+    var quiz := DataService.get_quiz(zone)
+    if quiz.is_empty():
+        push_warning("QuizPanel: quiz not found for zone %s" % zone)
+        return
+    _zone = zone
+    _questions = quiz.get("questions", []).duplicate(true)
+    _questions.shuffle()
+    _current_index = 0
+    _score = 0
+    _pass_score = int(quiz.get("pass_score", int(ceil(_questions.size() * 0.8))))
+    title_label.text = quiz.get("title", "%s Quiz" % zone.capitalize())
+    show()
+    _show_question()
+
+func _show_question() -> void:
+    if _current_index >= _questions.size():
+        _finish_quiz()
+        return
+    var question := _questions[_current_index]
+    question_label.text = question.get("prompt", "")
+    feedback_label.text = ""
+    _clear_options()
+    var options := question.get("options", [])
+    for i in range(options.size()):
+        var option_button := Button.new()
+        option_button.text = options[i]
+        option_button.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+        option_button.connect("pressed", Callable(self, "_on_option_selected").bind(i, option_button))
+        options_container.add_child(option_button)
+    _answered = false
+    next_button.disabled = true
+    progress_label.text = "Question %d/%d" % [_current_index + 1, _questions.size()]
+
+func _on_option_selected(index: int, button: Button) -> void:
+    if _answered:
+        return
+    _answered = true
+    var question := _questions[_current_index]
+    var correct := int(question.get("correct_index", 0))
+    var explanation := question.get("explanation", "")
+    var i := 0
+    for child in options_container.get_children():
+        if child is Button:
+            child.disabled = true
+            if i == correct:
+                child.add_theme_color_override("font_color", Color(0.1, 0.6, 0.2))
+            i += 1
+    if index == correct:
+        _score += 1
+        feedback_label.text = "Correct! %s" % explanation
+    else:
+        feedback_label.text = "Incorrect. %s" % explanation
+        button.add_theme_color_override("font_color", Color(0.7, 0.1, 0.1))
+    next_button.disabled = false
+
+func _on_next_pressed() -> void:
+    if not _answered:
+        return
+    _current_index += 1
+    _show_question()
+
+func _finish_quiz() -> void:
+    var passed := _score >= _pass_score
+    question_label.text = "You scored %d/%d." % [_score, _questions.size()]
+    feedback_label.text = passed ? "Badge unlocked!" : "Try again for a better score."
+    _clear_options()
+    next_button.disabled = true
+    emit_signal("quiz_completed", _zone, _score, passed)
+
+func _on_close_pressed() -> void:
+    hide()
+    emit_signal("panel_closed")
+
+func _clear_options() -> void:
+    for child in options_container.get_children():
+        child.queue_free()


### PR DESCRIPTION
## Summary
- create a new Godot 4 PalmQuest project with configured inputs and global services for persistence, audio, and data loading
- seed runtime JSON assets describing hotspots, quizzes, mini-game parameters, glossary entries, and sample production figures for the training plot
- implement the 3D training plot, hotspot interactions, HUD overlays, three mini-games, zone quizzes, and the production dashboard tied to saved player progress

## Testing
- not run (Godot project)

------
https://chatgpt.com/codex/tasks/task_e_68d09713d080832cb4fdd16c608bdca6